### PR TITLE
Add ipc_compression feature to arrow dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ members = ["crates/fluss", "crates/examples", "bindings/python"]
 fluss = { version = "0.1.0", path = "./crates/fluss" }
 tokio = { version = "1.44.2", features = ["full"] }
 clap = { version = "4.5.37", features = ["derive"] }
-arrow = "57.0.0"
+arrow = { version = "57.0.0", features = ["ipc_compression"] }
 chrono = { version = "0.4", features = ["clock", "std", "wasmbind"] }


### PR DESCRIPTION
by adding the ipc_compression fluss-rust client can read zstd compressed data from log tables

