### PR TITLE
chore: use log over tracing

### DIFF
--- a/crates/fluss/Cargo.toml
+++ b/crates/fluss/Cargo.toml
@@ -37,24 +37,23 @@ futures = "0.3"
 clap = { workspace = true }
 crc32c = "0.6.8"
 linked-hash-map = "0.5.6"
-prost = "0.13.5"
+prost = "0.14"
 rand = "0.9.1"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.140"
-thiserror = "1.0"
-tracing = "0.1"
+thiserror = "2"
+log = { version = "0.4", features = ["kv_std"] }
 tokio = { workspace = true }
 parking_lot = "0.12"
 bytes = "1.10.1"
 dashmap = "6.1.0"
 rust_decimal = "1"
-ordered-float = { version = "4", features = ["serde"] }
+ordered-float = { version = "5", features = ["serde"] }
 parse-display = "0.10"
 ref-cast = "1.0"
 jiff = { workspace = true }
 opendal = "0.55.0"
 url = "2.5.7"
-async-trait = "0.1.89"
 uuid = { version = "1.10", features = ["v4"] }
 tempfile = "3.23.0"
 
@@ -67,4 +66,4 @@ test-env-helpers = "0.2.2"
 
 
 [build-dependencies]
-prost-build = { version = "0.13.5" }
+prost-build = { version = "0.14" }

--- a/crates/fluss/src/client/write/broadcast.rs
+++ b/crates/fluss/src/client/write/broadcast.rs
@@ -19,7 +19,6 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Notify;
-use tracing::warn;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -111,7 +110,7 @@ where
     fn drop(&mut self) {
         let mut data = self.shared.data.write();
         if data.is_none() {
-            warn!("BroadcastOnce dropped without producing");
+            log::warn!("BroadcastOnce dropped without producing");
             *data = Some(Err(Error::Dropped));
             self.shared.notify.notify_waiters();
         }

--- a/crates/fluss/src/io/file_io.rs
+++ b/crates/fluss/src/io/file_io.rs
@@ -97,12 +97,10 @@ impl FileIOBuilder {
     }
 }
 
-#[async_trait::async_trait]
 pub trait FileRead: Send + Unpin + 'static {
-    async fn read(&self, range: Range<u64>) -> Result<Bytes>;
+    fn read(&self, range: Range<u64>) -> impl Future<Output = Result<Bytes>> + Send;
 }
 
-#[async_trait::async_trait]
 impl FileRead for opendal::Reader {
     async fn read(&self, range: Range<u64>) -> Result<Bytes> {
         Ok(opendal::Reader::read(self, range).await?.to_bytes())

--- a/crates/fluss/src/util/mod.rs
+++ b/crates/fluss/src/util/mod.rs
@@ -22,7 +22,6 @@ use std::hash::Hash;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tracing::warn;
 
 pub fn current_time_ms() -> i64 {
     SystemTime::now()
@@ -34,7 +33,7 @@ pub fn current_time_ms() -> i64 {
 pub async fn delete_file(file_path: PathBuf) {
     tokio::fs::remove_file(&file_path)
         .await
-        .unwrap_or_else(|e| warn!("Could not delete file: {:?}, error: {:?}", &file_path, e));
+        .unwrap_or_else(|err| log::warn!("Could not delete file: {file_path:?}, error: {err:?}"));
 }
 
 pub struct FairBucketStatusMap<S> {


### PR DESCRIPTION
Ref -

* https://fast.github.io/blog/fastrace-a-modern-approach-to-distributed-tracing-in-rust/
* https://www.tisonkun.org/2025/08/20/logforth/

And anyway tracing can be set to understand `log`'s output.