### PR TITLE
[client] Return exception for partitioned tables in Rust client

### DIFF
--- a/crates/fluss/src/client/connection.rs
+++ b/crates/fluss/src/client/connection.rs
@@ -77,6 +77,11 @@ impl FlussConnection {
     pub async fn get_table(&self, table_path: &TablePath) -> Result<FlussTable<'_>> {
         self.metadata.update_table_metadata(table_path).await?;
         let table_info = self.metadata.get_cluster().get_table(table_path).clone();
+        if table_info.is_partitioned() {
+            return Err(crate::error::Error::UnsupportedOperation {
+                message: "Partitioned tables are not supported".to_string(),
+            });
+        }
         Ok(FlussTable::new(self, self.metadata.clone(), table_info))
     }
 }

--- a/crates/fluss/src/error.rs
+++ b/crates/fluss/src/error.rs
@@ -100,6 +100,12 @@ pub enum Error {
 
     #[snafu(
         visibility(pub(crate)),
+        display("Fluss hitting unsupported operation error {}.", message)
+    )]
+    UnsupportedOperation { message: String },
+
+    #[snafu(
+        visibility(pub(crate)),
         display("Fluss hitting leader not available error {}.", message)
     )]
     LeaderNotAvailable { message: String },


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #99 

<!-- What is the purpose of the change -->
The current Rust client does not handle partitioned tables. To prevent incorrect usage,
this PR adds validation to return an `UnsupportedOperation` error when
`new_append()` or `new_scan()` is called on a partitioned table.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- Added new `UnsupportedOperation` error variant in `crates/fluss/src/error.rs` to handle unsupported operations
- Added partitioned table validation in `FlussTable::new_append()` - returns `UnsupportedOperation` error if the table is partitioned
- Changed `FlussTable::new_scan()` return type from `TableScan` to `Result<TableScan>` and added partitioned table validation
- Updated all call sites to handle the new `Result` return type:
  - `crates/examples/src/example_table.rs`
  - `crates/fluss/tests/integration/table.rs`
  - `crates/fluss/tests/integration/table_remote_scan.rs`
  - `bindings/python/src/table.rs`
  - `bindings/cpp/src/lib.rs`
- Updated doc examples in `crates/fluss/src/client/table/scanner.rs`

### Tests

<!-- List UT and IT cases to verify this change -->

- All existing unit tests pass (`cargo test --lib`)
- Integration tests updated to handle the new return type
- Verified with `cargo check`, `cargo clippy`, and `cargo fmt`


### API and Format

<!-- Does this change affect API or storage format -->

**API Change:** Yes
- `FlussTable::new_scan()` return type changed from `TableScan<'_>` to `Result<TableScan<'_>>`
- This is a breaking change for callers of `new_scan()`, but necessary to properly communicate the error condition

**Storage Format:** No

### Documentation

<!-- Does this change introduce a new feature -->

No.