### PR TITLE
chore: add integration tests for subscribe_batch and project_by_name

### DIFF
--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -625,7 +625,7 @@ impl LogScanner {
             bucket_offsets.insert(sub.bucket_id, sub.offset);
         }
 
-        let result = RUNTIME.block_on(async { self.inner.subscribe_batch(bucket_offsets).await });
+        let result = RUNTIME.block_on(async { self.inner.subscribe_batch(&bucket_offsets).await });
 
         match result {
             Ok(_) => ok_result(),

--- a/crates/fluss/src/client/table/scanner.rs
+++ b/crates/fluss/src/client/table/scanner.rs
@@ -223,7 +223,7 @@ impl LogScanner {
         Ok(())
     }
 
-    pub async fn subscribe_batch(&self, bucket_offsets: HashMap<i32, i64>) -> Result<()> {
+    pub async fn subscribe_batch(&self, bucket_offsets: &HashMap<i32, i64>) -> Result<()> {
         self.metadata
             .check_and_update_table_metadata(from_ref(&self.table_path))
             .await?;
@@ -236,8 +236,8 @@ impl LogScanner {
 
         let mut scan_bucket_offsets = HashMap::new();
         for (bucket_id, offset) in bucket_offsets {
-            let table_bucket = TableBucket::new(self.table_id, bucket_id);
-            scan_bucket_offsets.insert(table_bucket, offset);
+            let table_bucket = TableBucket::new(self.table_id, *bucket_id);
+            scan_bucket_offsets.insert(table_bucket, *offset);
         }
 
         self.log_scanner_status


### PR DESCRIPTION
- Add `test_subscribe_batch`: tests `LogScanner::subscribe_batch()` with HashMap
- Add `test_project_by_name`: tests `TableScan::project_by_name()` with column names
- Both tests include error case validation

Linked issue: #31