### PR TITLE
[TASK-240] Fire-and-forget behaviour for efficient batching

### DIFF
--- a/bindings/cpp/examples/example.cpp
+++ b/bindings/cpp/examples/example.cpp
@@ -91,6 +91,7 @@ int main() {
         {3, "Charlie", 92.1f, 35},
     };
 
+    // Fire-and-forget: queue rows, flush at end
     for (const auto& r : rows) {
         fluss::GenericRow row;
         row.SetInt32(0, r.id);
@@ -100,7 +101,20 @@ int main() {
         check("append", writer.Append(row));
     }
     check("flush", writer.Flush());
-    std::cout << "Wrote " << rows.size() << " rows" << std::endl;
+    std::cout << "Wrote " << rows.size() << " rows (fire-and-forget + flush)" << std::endl;
+
+    // Per-record acknowledgment
+    {
+        fluss::GenericRow row;
+        row.SetInt32(0, 100);
+        row.SetString(1, "AckTest");
+        row.SetFloat32(2, 99.9f);
+        row.SetInt32(3, 42);
+        fluss::WriteResult wr;
+        check("append", writer.Append(row, wr));
+        check("wait", wr.Wait());
+        std::cout << "Row acknowledged by server" << std::endl;
+    }
 
     // 6) Scan
     fluss::LogScanner scanner;

--- a/bindings/cpp/include/fluss.hpp
+++ b/bindings/cpp/include/fluss.hpp
@@ -37,6 +37,7 @@ namespace ffi {
     struct Admin;
     struct Table;
     struct AppendWriter;
+    struct WriteResult;
     struct LogScanner;
 }  // namespace ffi
 
@@ -404,6 +405,7 @@ struct LakeSnapshot {
 };
 
 class AppendWriter;
+class WriteResult;
 class LogScanner;
 class Admin;
 class Table;
@@ -526,6 +528,30 @@ private:
     std::vector<size_t> projection_;
 };
 
+class WriteResult {
+public:
+    WriteResult() noexcept;
+    ~WriteResult() noexcept;
+
+    WriteResult(const WriteResult&) = delete;
+    WriteResult& operator=(const WriteResult&) = delete;
+    WriteResult(WriteResult&& other) noexcept;
+    WriteResult& operator=(WriteResult&& other) noexcept;
+
+    bool Available() const;
+
+    /// Wait for server acknowledgment of the write.
+    /// For fire-and-forget, simply let the WriteResult go out of scope.
+    Result Wait();
+
+private:
+    friend class AppendWriter;
+    WriteResult(ffi::WriteResult* inner) noexcept;
+
+    void Destroy() noexcept;
+    ffi::WriteResult* inner_{nullptr};
+};
+
 class AppendWriter {
 public:
     AppendWriter() noexcept;
@@ -539,6 +565,7 @@ public:
     bool Available() const;
 
     Result Append(const GenericRow& row);
+    Result Append(const GenericRow& row, WriteResult& out);
     Result Flush();
 
 private:

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -180,6 +180,7 @@ mod ffi {
         type Admin;
         type Table;
         type AppendWriter;
+        type WriteResult;
         type LogScanner;
 
         // Connection
@@ -239,8 +240,11 @@ mod ffi {
 
         // AppendWriter
         unsafe fn delete_append_writer(writer: *mut AppendWriter);
-        fn append(self: &mut AppendWriter, row: &FfiGenericRow) -> FfiResult;
+        fn append(self: &mut AppendWriter, row: &FfiGenericRow) -> Result<Box<WriteResult>>;
         fn flush(self: &mut AppendWriter) -> FfiResult;
+
+        // WriteResult — dropped automatically via rust::Box, or call wait() for ack
+        fn wait(self: &mut WriteResult) -> FfiResult;
 
         // LogScanner
         unsafe fn delete_log_scanner(scanner: *mut LogScanner);
@@ -283,6 +287,10 @@ pub struct Table {
 
 pub struct AppendWriter {
     inner: fcore::client::AppendWriter,
+}
+
+pub struct WriteResult {
+    inner: Option<fcore::client::WriteResultFuture>,
 }
 
 pub struct LogScanner {
@@ -706,15 +714,16 @@ unsafe fn delete_append_writer(writer: *mut AppendWriter) {
 }
 
 impl AppendWriter {
-    fn append(&mut self, row: &ffi::FfiGenericRow) -> ffi::FfiResult {
+    fn append(&mut self, row: &ffi::FfiGenericRow) -> Result<Box<WriteResult>, String> {
         let generic_row = types::ffi_row_to_core(row);
 
-        let result = RUNTIME.block_on(async { self.inner.append(&generic_row).await });
+        let result_future = RUNTIME
+            .block_on(async { self.inner.append(&generic_row).await })
+            .map_err(|e| format!("Failed to append: {e}"))?;
 
-        match result {
-            Ok(_) => ok_result(),
-            Err(e) => err_result(1, e.to_string()),
-        }
+        Ok(Box::new(WriteResult {
+            inner: Some(result_future),
+        }))
     }
 
     fn flush(&mut self) -> ffi::FfiResult {
@@ -723,6 +732,20 @@ impl AppendWriter {
         match result {
             Ok(_) => ok_result(),
             Err(e) => err_result(1, e.to_string()),
+        }
+    }
+}
+
+impl WriteResult {
+    fn wait(&mut self) -> ffi::FfiResult {
+        if let Some(future) = self.inner.take() {
+            let result = RUNTIME.block_on(future);
+            match result {
+                Ok(_) => ok_result(),
+                Err(e) => err_result(1, e.to_string()),
+            }
+        } else {
+            ok_result()
         }
     }
 }

--- a/bindings/python/src/table.rs
+++ b/bindings/python/src/table.rs
@@ -531,35 +531,59 @@ pub struct AppendWriter {
 
 #[pymethods]
 impl AppendWriter {
-    /// Write Arrow table data
+    /// Write Arrow table data (fire-and-forget, use flush() to ensure delivery)
     pub fn write_arrow(&self, py: Python, table: Py<PyAny>) -> PyResult<()> {
         // Convert Arrow Table to batches and write each batch
         let batches = table.call_method0(py, "to_batches")?;
         let batch_list: Vec<Py<PyAny>> = batches.extract(py)?;
 
         for batch in batch_list {
-            self.write_arrow_batch(py, batch)?;
+            // Drop the ack coroutine — fire-and-forget
+            let _ = self.write_arrow_batch(py, batch)?;
         }
         Ok(())
     }
 
     /// Write Arrow batch data
-    pub fn write_arrow_batch(&self, py: Python, batch: Py<PyAny>) -> PyResult<()> {
+    ///
+    /// Returns:
+    ///     A coroutine that can be awaited for server acknowledgment,
+    ///     or ignored for fire-and-forget behavior.
+    pub fn write_arrow_batch<'py>(
+        &self,
+        py: Python<'py>,
+        batch: Py<PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         // This shares the underlying Arrow buffers without copying data
         let batch_bound = batch.bind(py);
         let rust_batch: ArrowRecordBatch = FromPyArrow::from_pyarrow_bound(batch_bound)
             .map_err(|e| FlussError::new_err(format!("Failed to convert RecordBatch: {e}")))?;
 
         let inner = self.inner.clone();
-        // Release the GIL before blocking on async operation
-        let result = py.detach(|| {
-            TOKIO_RUNTIME.block_on(async { inner.append_arrow_batch(rust_batch).await })
-        });
 
-        result.map_err(|e| FlussError::new_err(e.to_string()))
+        future_into_py(py, async move {
+            let result_future = inner
+                .append_arrow_batch(rust_batch)
+                .await
+                .map_err(|e| FlussError::new_err(e.to_string()))?;
+
+            Python::attach(|py| {
+                future_into_py(py, async move {
+                    result_future
+                        .await
+                        .map_err(|e| FlussError::new_err(e.to_string()))?;
+                    Ok(())
+                })
+                .map(|bound| bound.unbind())
+            })
+        })
     }
 
     /// Append a single row to the table
+    ///
+    /// Returns:
+    ///     A coroutine that can be awaited for server acknowledgment,
+    ///     or ignored for fire-and-forget behavior.
     pub fn append<'py>(
         &self,
         py: Python<'py>,
@@ -569,10 +593,20 @@ impl AppendWriter {
         let inner = self.inner.clone();
 
         future_into_py(py, async move {
-            inner
+            let result_future = inner
                 .append(&generic_row)
                 .await
-                .map_err(|e| FlussError::new_err(e.to_string()))
+                .map_err(|e| FlussError::new_err(e.to_string()))?;
+
+            Python::attach(|py| {
+                future_into_py(py, async move {
+                    result_future
+                        .await
+                        .map_err(|e| FlussError::new_err(e.to_string()))?;
+                    Ok(())
+                })
+                .map(|bound| bound.unbind())
+            })
         })
     }
 

--- a/crates/examples/src/example_kv_table.rs
+++ b/crates/examples/src/example_kv_table.rs
@@ -65,6 +65,7 @@ pub async fn main() -> Result<()> {
         upsert_writer.upsert(&row).await?;
         println!("Upserted: {row:?}");
     }
+    upsert_writer.flush().await?;
 
     println!("\n=== Looking up ===");
     let mut lookuper = table.new_lookup()?.create_lookuper()?;
@@ -84,7 +85,7 @@ pub async fn main() -> Result<()> {
     row.set_field(0, 1);
     row.set_field(1, "Verso");
     row.set_field(2, 33i64);
-    upsert_writer.upsert(&row).await?;
+    upsert_writer.upsert(&row).await?.await?;
     println!("Updated: {row:?}");
 
     let result = lookuper.lookup(&make_key(1)).await?;
@@ -99,7 +100,7 @@ pub async fn main() -> Result<()> {
     // For delete, only primary key field needs to be set; other fields can remain null
     let mut row = GenericRow::new(3);
     row.set_field(0, 2);
-    upsert_writer.delete(&row).await?;
+    upsert_writer.delete(&row).await?.await?;
     println!("Deleted row with id=2");
 
     let result = lookuper.lookup(&make_key(2)).await?;

--- a/crates/examples/src/example_partitioned_kv_table.rs
+++ b/crates/examples/src/example_partitioned_kv_table.rs
@@ -77,6 +77,7 @@ pub async fn main() -> Result<()> {
         upsert_writer.upsert(&row).await?;
         println!("Upserted: {row:?}");
     }
+    upsert_writer.flush().await?;
 
     println!("\n=== Looking up ===");
     let mut lookuper = table.new_lookup()?.create_lookuper()?;
@@ -101,7 +102,7 @@ pub async fn main() -> Result<()> {
     row.set_field(1, "APAC");
     row.set_field(2, 1i64);
     row.set_field(3, 4321i64);
-    upsert_writer.upsert(&row).await?;
+    upsert_writer.upsert(&row).await?.await?;
     println!("Updated: {row:?}");
 
     let result = lookuper.lookup(&make_key(1001, "APAC", 1)).await?;
@@ -117,7 +118,7 @@ pub async fn main() -> Result<()> {
     row.set_field(0, 1002);
     row.set_field(1, "EMEA");
     row.set_field(2, 2i64);
-    upsert_writer.delete(&row).await?;
+    upsert_writer.delete(&row).await?.await?;
     println!("Deleted: {row:?}");
 
     let result = lookuper.lookup(&make_key(1002, "EMEA", 2)).await?;

--- a/crates/fluss/tests/integration/log_table.rs
+++ b/crates/fluss/tests/integration/log_table.rs
@@ -109,6 +109,7 @@ mod table_test {
             .await
             .expect("Failed to append batch");
 
+        // Flush to ensure all writes are acknowledged
         append_writer.flush().await.expect("Failed to flush");
 
         // Create scanner to verify appended records
@@ -231,6 +232,9 @@ mod table_test {
             .append_arrow_batch(batch)
             .await
             .expect("Failed to append batch");
+
+        // Flush to ensure all writes are acknowledged
+        append_writer.flush().await.expect("Failed to flush");
 
         tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 


### PR DESCRIPTION
 ## Summary
 
 closes  #240 
 
 Fire-and-forget write semantics for efficient batching                                                                                                                                                                                          
                                                                
  Write operations (`upsert`, `delete`, `append`) now return a `WriteResultFuture` immediately after queueing the record, instead of blocking until server acknowledgment. This enables efficient batching and records accumulate in the               
  `RecordAccumulator` and are sent in batches by the background `Sender`, similar to rdkafka's `DeliveryFuture`.
                                                                                                                                                                                                                                                     
  ### Usage patterns                                                               

  **Fire-and-forget** — queue writes, flush at end:
  ```rust
  writer.upsert(&row1).await?;
  writer.upsert(&row2).await?;
  writer.flush().await?; // ensures all writes are acknowledged
```

  Per-record acknowledgment — double-await for read-after-write consistency:
```rust
  writer.upsert(&row).await?.await?;
```

Notes:
  - Rust core: upsert(), delete(), append(), append_arrow_batch() return Result<WriteResultFuture> instead of Result<()>/Result<UpsertResult>
  - Python bindings: Methods return an awaitable ack handle via nested future_into_py, both UpsertWriter and AppendWriter support both patterns
  - C++ bindings: Added WriteResult class with Wait() method; AppendWriter::Append() has two overloads — fire-and-forget (single arg) and with ack handle (out parameter)
  - Examples and tests: Updated across all languages to demonstrate both patterns
