### PR TITLE
[TASK-287] Support projection by names in CPP

### DIFF
--- a/bindings/cpp/examples/example.cpp
+++ b/bindings/cpp/examples/example.cpp
@@ -197,7 +197,7 @@ int main() {
     std::vector<size_t> projected_columns = {0, 7};
     fluss::LogScanner projected_scanner;
     check("new_log_scanner_with_projection",
-          table.NewScan().Project(projected_columns).CreateLogScanner(projected_scanner));
+          table.NewScan().ProjectByIndex(projected_columns).CreateLogScanner(projected_scanner));
 
     for (int b = 0; b < buckets; ++b) {
         check("subscribe_projected", projected_scanner.Subscribe(b, 0));
@@ -372,7 +372,7 @@ int main() {
     fluss::LogScanner projected_arrow_scanner;
     check("new_record_batch_log_scanner_with_projection",
           table.NewScan()
-              .Project(projected_columns)
+              .ProjectByIndex(projected_columns)
               .CreateRecordBatchScanner(projected_arrow_scanner));
 
     for (int b = 0; b < buckets; ++b) {

--- a/bindings/cpp/include/fluss.hpp
+++ b/bindings/cpp/include/fluss.hpp
@@ -939,7 +939,7 @@ class TableScan {
     TableScan(TableScan&&) noexcept = default;
     TableScan& operator=(TableScan&&) noexcept = default;
 
-    TableScan& Project(std::vector<size_t> column_indices);
+    TableScan& ProjectByIndex(std::vector<size_t> column_indices);
     TableScan& ProjectByName(std::vector<std::string> column_names);
 
     Result CreateLogScanner(LogScanner& out);

--- a/bindings/cpp/src/table.cpp
+++ b/bindings/cpp/src/table.cpp
@@ -129,7 +129,7 @@ TableScan Table::NewScan() { return TableScan(table_); }
 // TableScan implementation
 TableScan::TableScan(ffi::Table* table) noexcept : table_(table) {}
 
-TableScan& TableScan::Project(std::vector<size_t> column_indices) {
+TableScan& TableScan::ProjectByIndex(std::vector<size_t> column_indices) {
     projection_ = std::move(column_indices);
     name_projection_.clear();
     return *this;


### PR DESCRIPTION
closes #287 
                                                                                                                                                                                                                                                     
  - Add ProjectByName to CPP TableScan, bringing parity with Rust and Python

  // By index
  table.NewScan().ProjectByIndex{0, 7}).CreateLogScanner(scanner);

  // By name (new)
  table.NewScan().ProjectByName({"id", "updated_at"}).CreateLogScanner(scanner);