### PR TITLE
[TASK-293] Builder pattern, cleanup, consistent API

### DIFF
--- a/bindings/cpp/examples/example.cpp
+++ b/bindings/cpp/examples/example.cpp
@@ -79,7 +79,7 @@ int main() {
 
     // 5) Write rows with scalar and temporal values
     fluss::AppendWriter writer;
-    check("new_append_writer", table.NewAppendWriter(writer));
+    check("new_append_writer", table.NewAppend().CreateWriter(writer));
 
     struct RowData {
         int id;
@@ -423,7 +423,7 @@ int main() {
     check("get_decimal_table", conn.GetTable(decimal_table_path, decimal_table));
 
     fluss::AppendWriter decimal_writer;
-    check("new_decimal_writer", decimal_table.NewAppendWriter(decimal_writer));
+    check("new_decimal_writer", decimal_table.NewAppend().CreateWriter(decimal_writer));
 
     // Just provide the value — Rust resolves (p,s) from schema
     {
@@ -512,7 +512,7 @@ int main() {
     check("get_partitioned_table", conn.GetTable(partitioned_table_path, partitioned_table));
 
     fluss::AppendWriter partitioned_writer;
-    check("new_partitioned_writer", partitioned_table.NewAppendWriter(partitioned_writer));
+    check("new_partitioned_writer", partitioned_table.NewAppend().CreateWriter(partitioned_writer));
 
     struct PartitionedRow {
         int id;

--- a/bindings/cpp/src/connection.cpp
+++ b/bindings/cpp/src/connection.cpp
@@ -17,9 +17,9 @@
  * under the License.
  */
 
+#include "ffi_converter.hpp"
 #include "fluss.hpp"
 #include "lib.rs.h"
-#include "ffi_converter.hpp"
 #include "rust/cxx.h"
 
 namespace fluss {
@@ -35,9 +35,7 @@ void Connection::Destroy() noexcept {
     }
 }
 
-Connection::Connection(Connection&& other) noexcept : conn_(other.conn_) {
-    other.conn_ = nullptr;
-}
+Connection::Connection(Connection&& other) noexcept : conn_(other.conn_) { other.conn_ = nullptr; }
 
 Connection& Connection::operator=(Connection&& other) noexcept {
     if (this != &other) {


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                       
 closes #293 
                                                              
  - Align CPP Table API with Java/Rust builder pattern                                                                                                                                                                                       
  - Rename `Connection::Connect` to `Connection::Create` to align with Java's `createConnection`                                                                                                                                                     
                                                                                                                                                                                                                                                     
  ## API changes                                           
  ### Connection
  Connection::Connect(addr, conn) ->  Connection::Create(addr, conn)

 ### Append
  table.NewAppendWriter(writer) -> table.NewAppend().CreateWriter(writer)

  ### Upsert
  table.NewUpsertWriter(writer)-> table.NewUpsert().CreateWriter(writer)
  table.NewUpsertWriter(writer, names)   -> table.NewUpsert().PartialUpdateByName(names).CreateWriter(writer)
  table.NewUpsertWriter(writer, indices)  -> table.NewUpsert().PartialUpdateByIndex(indices).CreateWriter(writer)

 ### Lookup
  table.NewLookuper(lookuper) -> table.NewLookup().CreateLookuper(lookuper)

  Rust FFI consolidation