### PR TITLE
[TASK-303] add unsubscribe to all clients

### DIFF
--- a/bindings/cpp/include/fluss.hpp
+++ b/bindings/cpp/include/fluss.hpp
@@ -1278,6 +1278,7 @@ class LogScanner {
     Result Subscribe(const std::vector<BucketSubscription>& bucket_offsets);
     Result SubscribePartitionBuckets(int64_t partition_id, int32_t bucket_id, int64_t start_offset);
     Result SubscribePartitionBuckets(const std::vector<PartitionBucketSubscription>& subscriptions);
+    Result Unsubscribe(int32_t bucket_id);
     Result UnsubscribePartition(int64_t partition_id, int32_t bucket_id);
     Result Poll(int64_t timeout_ms, ScanRecords& out);
     Result PollRecordBatch(int64_t timeout_ms, ArrowRecordBatches& out);

--- a/bindings/cpp/src/table.cpp
+++ b/bindings/cpp/src/table.cpp
@@ -640,6 +640,15 @@ Result LogScanner::SubscribePartitionBuckets(
     return utils::from_ffi_result(ffi_result);
 }
 
+Result LogScanner::Unsubscribe(int32_t bucket_id) {
+    if (!Available()) {
+        return utils::make_client_error("LogScanner not available");
+    }
+
+    auto ffi_result = scanner_->unsubscribe(bucket_id);
+    return utils::from_ffi_result(ffi_result);
+}
+
 Result LogScanner::UnsubscribePartition(int64_t partition_id, int32_t bucket_id) {
     if (!Available()) {
         return utils::make_client_error("LogScanner not available");

--- a/bindings/python/API_REFERENCE.md
+++ b/bindings/python/API_REFERENCE.md
@@ -146,6 +146,7 @@ Builder for creating a `Lookuper`. Obtain via `FlussTable.new_lookup()`.
 | `.subscribe_buckets(bucket_offsets)` | Subscribe to multiple buckets (`{bucket_id: offset}`) |
 | `.subscribe_partition(partition_id, bucket_id, start_offset)` | Subscribe to a partition bucket |
 | `.subscribe_partition_buckets(partition_bucket_offsets)` | Subscribe to multiple partition+bucket combos (`{(part_id, bucket_id): offset}`) |
+| `.unsubscribe(bucket_id)` | Unsubscribe from a bucket (non-partitioned tables) |
 | `.unsubscribe_partition(partition_id, bucket_id)` | Unsubscribe from a partition bucket |
 | `.poll(timeout_ms) -> list[ScanRecord]` | Poll individual records (record scanner only) |
 | `.poll_arrow(timeout_ms) -> pa.Table` | Poll as Arrow Table (batch scanner only) |

--- a/bindings/python/example/example.py
+++ b/bindings/python/example/example.py
@@ -374,6 +374,20 @@ async def main():
     except Exception as e:
         print(f"Error during record scanning: {e}")
 
+    # Demo: unsubscribe — unsubscribe from a bucket (non-partitioned tables)
+    print("\n--- Testing unsubscribe ---")
+    try:
+        unsub_scanner = await table.new_scan().create_record_batch_log_scanner()
+        unsub_scanner.subscribe_buckets({i: fluss.EARLIEST_OFFSET for i in range(num_buckets)})
+        print(f"Subscribed to {num_buckets} buckets")
+        # Unsubscribe from bucket 0 — future polls will skip this bucket
+        unsub_scanner.unsubscribe(bucket_id=0)
+        print("Unsubscribed from bucket 0")
+        remaining = unsub_scanner.poll_arrow(5000)
+        print(f"After unsubscribe, got {remaining.num_rows} records (from remaining buckets)")
+    except Exception as e:
+        print(f"Error during unsubscribe test: {e}")
+
     # =====================================================
     # Demo: Primary Key Table with Lookup and Upsert
     # =====================================================

--- a/bindings/python/fluss/__init__.pyi
+++ b/bindings/python/fluss/__init__.pyi
@@ -573,6 +573,13 @@ class LogScanner:
                 Example: {(partition_id_1, 0): EARLIEST_OFFSET, (partition_id_2, 1): 100}
         """
         ...
+    def unsubscribe(self, bucket_id: int) -> None:
+        """Unsubscribe from a specific bucket (non-partitioned tables only).
+
+        Args:
+            bucket_id: The bucket ID to unsubscribe from
+        """
+        ...
     def unsubscribe_partition(self, partition_id: int, bucket_id: int) -> None:
         """Unsubscribe from a specific partition bucket (partitioned tables only).
 

--- a/bindings/python/src/table.rs
+++ b/bindings/python/src/table.rs
@@ -1703,6 +1703,19 @@ impl LogScanner {
         })
     }
 
+    /// Unsubscribe from a specific bucket (non-partitioned tables only).
+    ///
+    /// Args:
+    ///     bucket_id: The bucket ID to unsubscribe from
+    fn unsubscribe(&self, py: Python, bucket_id: i32) -> PyResult<()> {
+        py.detach(|| {
+            TOKIO_RUNTIME.block_on(async {
+                with_scanner!(&self.scanner, unsubscribe(bucket_id))
+                    .map_err(|e| FlussError::from_core_error(&e))
+            })
+        })
+    }
+
     /// Unsubscribe from a specific partition bucket (partitioned tables only).
     ///
     /// Args:

--- a/crates/fluss/tests/integration/log_table.rs
+++ b/crates/fluss/tests/integration/log_table.rs
@@ -158,6 +158,18 @@ mod table_test {
                 i
             );
         }
+
+        // Test unsubscribe: unsubscribe from bucket 0, verify no error
+        log_scanner
+            .unsubscribe(0)
+            .await
+            .expect("Failed to unsubscribe from bucket 0");
+
+        // Verify unsubscribe_partition fails on a non-partitioned table
+        assert!(
+            log_scanner.unsubscribe_partition(0, 0).await.is_err(),
+            "unsubscribe_partition should fail on a non-partitioned table"
+        );
     }
 
     #[tokio::test]

--- a/docs/rust-client.md
+++ b/docs/rust-client.md
@@ -384,6 +384,13 @@ bucket_offsets.insert(1, 100i64);  // bucket 1 from offset 100
 log_scanner.subscribe_buckets(&bucket_offsets).await?;
 ```
 
+### Unsubscribe from a Bucket
+
+```rust
+// Unsubscribe from a specific bucket (non-partitioned tables)
+log_scanner.unsubscribe(bucket_id).await?;
+```
+
 ### Unsubscribe from a Partition
 
 ```rust


### PR DESCRIPTION
## Summary
  closes #303
  
  - Add `unsubscribe(bucket)` method for non-partitioned tables across Rust core, Python, and C++ clients  
  - Update related docs, examples, etc
