### PR TITLE
Add missing custom properties method and doc for table descriptor builder in C++. Add assertion for custom property in integration test.

### DIFF
--- a/website/docs/user-guide/cpp/api-reference.md
+++ b/website/docs/user-guide/cpp/api-reference.md
@@ -286,15 +286,16 @@ When using `table.NewRow()`, the `Set()` method auto-routes to the correct type 
 
 ## `TableDescriptor::Builder`
 
-| Method                                                                      |  Description               |
-|-----------------------------------------------------------------------------|----------------------------|
-| `SetSchema(const Schema& schema) -> Builder&`                               | Set the table schema       |
-| `SetPartitionKeys(const std::vector<std::string>& keys) -> Builder&`        | Set partition key columns  |
-| `SetBucketCount(int32_t count) -> Builder&`                                 | Set the number of buckets  |
-| `SetBucketKeys(const std::vector<std::string>& keys) -> Builder&`           | Set bucket key columns     |
-| `SetProperty(const std::string& key, const std::string& value) -> Builder&` | Set a table property       |
-| `SetComment(const std::string& comment) -> Builder&`                        | Set a table comment        |
-| `Build() -> TableDescriptor`                                                | Build the table descriptor |
+| Method                                                                            | Description                |
+|-----------------------------------------------------------------------------------|----------------------------|
+| `SetSchema(const Schema& schema) -> Builder&`                                     | Set the table schema       |
+| `SetPartitionKeys(const std::vector<std::string>& keys) -> Builder&`              | Set partition key columns  |
+| `SetBucketCount(int32_t count) -> Builder&`                                       | Set the number of buckets  |
+| `SetBucketKeys(const std::vector<std::string>& keys) -> Builder&`                 | Set bucket key columns     |
+| `SetProperty(const std::string& key, const std::string& value) -> Builder&`       | Set a table property       |
+| `SetCustomProperty(const std::string& key, const std::string& value) -> Builder&` | Set a custom property      |
+| `SetComment(const std::string& comment) -> Builder&`                              | Set a table comment        |
+| `Build() -> TableDescriptor`                                                      | Build the table descriptor |
 
 ## `DataType`
 
@@ -336,22 +337,23 @@ When using `table.NewRow()`, the `Set()` method auto-routes to the correct type 
 
 ## `TableInfo`
 
-| Field             | Type                                           |  Description                        |
-|-------------------|------------------------------------------------|-------------------------------------|
-| `table_id`        | `int64_t`                                      | Table ID                            |
-| `schema_id`       | `int32_t`                                      | Schema ID                           |
-| `table_path`      | `TablePath`                                    | Table path                          |
-| `created_time`    | `int64_t`                                      | Creation timestamp                  |
-| `modified_time`   | `int64_t`                                      | Last modification timestamp         |
-| `primary_keys`    | `std::vector<std::string>`                     | Primary key columns                 |
-| `bucket_keys`     | `std::vector<std::string>`                     | Bucket key columns                  |
-| `partition_keys`  | `std::vector<std::string>`                     | Partition key columns               |
-| `num_buckets`     | `int32_t`                                      | Number of buckets                   |
-| `has_primary_key` | `bool`                                         | Whether the table has a primary key |
-| `is_partitioned`  | `bool`                                         | Whether the table is partitioned    |
-| `properties`      | `std::unordered_map<std::string, std::string>` | Table properties                    |
-| `comment`         | `std::string`                                  | Table comment                       |
-| `schema`          | `Schema`                                       | Table schema                        |
+| Field               | Type                                           | Description                         |
+|---------------------|------------------------------------------------|-------------------------------------|
+| `table_id`          | `int64_t`                                      | Table ID                            |
+| `schema_id`         | `int32_t`                                      | Schema ID                           |
+| `table_path`        | `TablePath`                                    | Table path                          |
+| `created_time`      | `int64_t`                                      | Creation timestamp                  |
+| `modified_time`     | `int64_t`                                      | Last modification timestamp         |
+| `primary_keys`      | `std::vector<std::string>`                     | Primary key columns                 |
+| `bucket_keys`       | `std::vector<std::string>`                     | Bucket key columns                  |
+| `partition_keys`    | `std::vector<std::string>`                     | Partition key columns               |
+| `num_buckets`       | `int32_t`                                      | Number of buckets                   |
+| `has_primary_key`   | `bool`                                         | Whether the table has a primary key |
+| `is_partitioned`    | `bool`                                         | Whether the table is partitioned    |
+| `properties`        | `std::unordered_map<std::string, std::string>` | Table properties                    |
+| `custom_properties` | `std::unordered_map<std::string, std::string>` | Custom properties                   |
+| `comment`           | `std::string`                                  | Table comment                       |
+| `schema`            | `Schema`                                       | Table schema                        |
 
 ## Temporal Types
 

--- a/website/docs/user-guide/rust/api-reference.md
+++ b/website/docs/user-guide/rust/api-reference.md
@@ -239,27 +239,30 @@ writer.append(&row)?.await?;
 
 ## `TableDescriptor`
 
-| Method                                             |  Description                         |
-|----------------------------------------------------|--------------------------------------|
-| `fn builder() -> TableDescriptorBuilder`           | Create a table descriptor builder    |
-| `fn schema(&self) -> &Schema`                      | Get the table schema                 |
-| `fn partition_keys(&self) -> &[String]`            | Get partition key column names       |
-| `fn has_primary_key(&self) -> bool`                | Check if the table has a primary key |
-| `fn properties(&self) -> &HashMap<String, String>` | Get all table properties             |
-| `fn comment(&self) -> Option<&str>`                | Get table comment                    |
+| Method                                                    | Description                          |
+|-----------------------------------------------------------|--------------------------------------|
+| `fn builder() -> TableDescriptorBuilder`                  | Create a table descriptor builder    |
+| `fn schema(&self) -> &Schema`                             | Get the table schema                 |
+| `fn partition_keys(&self) -> &[String]`                   | Get partition key column names       |
+| `fn has_primary_key(&self) -> bool`                       | Check if the table has a primary key |
+| `fn properties(&self) -> &HashMap<String, String>`        | Get all table properties             |
+| `fn custom_properties(&self) -> &HashMap<String, String>` | Get custom properties                |
+| `fn comment(&self) -> Option<&str>`                       | Get table comment                    |
 
 ## `TableDescriptorBuilder`
 
-| Method                                                                           |  Description                                |
-|----------------------------------------------------------------------------------|---------------------------------------------|
-| `fn schema(schema: Schema) -> Self`                                              | Set the schema                              |
-| `fn log_format(format: LogFormat) -> Self`                                       | Set log format (e.g., `LogFormat::ARROW`)   |
-| `fn kv_format(format: KvFormat) -> Self`                                         | Set KV format (e.g., `KvFormat::COMPACTED`) |
-| `fn property(key: &str, value: &str) -> Self`                                    | Set a table property                        |
-| `fn partitioned_by(keys: Vec<&str>) -> Self`                                     | Set partition columns                       |
-| `fn distributed_by(bucket_count: Option<i32>, bucket_keys: Vec<String>) -> Self` | Set bucket distribution                     |
-| `fn comment(comment: &str) -> Self`                                              | Set table comment                           |
-| `fn build() -> Result<TableDescriptor>`                                          | Build the table descriptor                  |
+| Method                                                                                    | Description                                 |
+|-------------------------------------------------------------------------------------------|---------------------------------------------|
+| `fn schema(schema: Schema) -> Self`                                                       | Set the schema                              |
+| `fn log_format(format: LogFormat) -> Self`                                                | Set log format (e.g., `LogFormat::ARROW`)   |
+| `fn kv_format(format: KvFormat) -> Self`                                                  | Set KV format (e.g., `KvFormat::COMPACTED`) |
+| `fn property(key: &str, value: &str) -> Self`                                             | Set a table property                        |
+| `fn custom_property(key: impl Into<String>, value: impl Into<String>) -> Self`            | Set a single custom property                |
+| `fn custom_properties(properties: HashMap<impl Into<String>, impl Into<String>>) -> Self` | Set custom properties                       |
+| `fn partitioned_by(keys: Vec<&str>) -> Self`                                              | Set partition columns                       |
+| `fn distributed_by(bucket_count: Option<i32>, bucket_keys: Vec<String>) -> Self`          | Set bucket distribution                     |
+| `fn comment(comment: &str) -> Self`                                                       | Set table comment                           |
+| `fn build() -> Result<TableDescriptor>`                                                   | Build the table descriptor                  |
 
 ## `TablePath`
 


### PR DESCRIPTION
### Purpose

Linked issue: close #335 

### Brief change log


- Add missing custom properties method in C++ TableDescriptionBuilder
- Add custom properties assertions in integration test
- Updated C++ documentation around custom properties
- Also adds missing helper method for log/kv format in C++
- Updated Rust documentation around custom properties

### Tests

Integration tests ran and completed