### PR TITLE
Fix API error not being propagated on python side

### DIFF
--- a/bindings/python/src/admin.rs
+++ b/bindings/python/src/admin.rs
@@ -363,7 +363,7 @@ impl FlussAdmin {
             admin
                 .drop_table(&core_table_path, ignore_if_not_exists)
                 .await
-                .map_err(|e| FlussError::new_err(format!("Failed to drop table: {e}")))?;
+                .map_err(|e| FlussError::from_core_error(&e))?;
 
             Python::attach(|py| Ok(py.None()))
         })
@@ -401,7 +401,7 @@ impl FlussAdmin {
             let offsets = admin
                 .list_offsets(&core_table_path, &bucket_ids, offset_spec)
                 .await
-                .map_err(|e| FlussError::new_err(format!("Failed to list offsets: {e}")))?;
+                .map_err(|e| FlussError::from_core_error(&e))?;
 
             Python::attach(|py| {
                 let dict = pyo3::types::PyDict::new(py);
@@ -448,9 +448,7 @@ impl FlussAdmin {
             let offsets = admin
                 .list_partition_offsets(&core_table_path, &partition_name, &bucket_ids, offset_spec)
                 .await
-                .map_err(|e| {
-                    FlussError::new_err(format!("Failed to list partition offsets: {e}"))
-                })?;
+                .map_err(|e| FlussError::from_core_error(&e))?;
 
             Python::attach(|py| {
                 let dict = pyo3::types::PyDict::new(py);
@@ -487,7 +485,7 @@ impl FlussAdmin {
             admin
                 .create_partition(&core_table_path, &core_partition_spec, ignore_if_exists)
                 .await
-                .map_err(|e| FlussError::new_err(format!("Failed to create partition: {e}")))?;
+                .map_err(|e| FlussError::from_core_error(&e))?;
 
             Python::attach(|py| Ok(py.None()))
         })
@@ -512,7 +510,7 @@ impl FlussAdmin {
             let partition_infos = admin
                 .list_partition_infos(&core_table_path)
                 .await
-                .map_err(|e| FlussError::new_err(format!("Failed to list partitions: {e}")))?;
+                .map_err(|e| FlussError::from_core_error(&e))?;
 
             Python::attach(|py| {
                 let py_list = pyo3::types::PyList::empty(py);

--- a/crates/fluss/src/error.rs
+++ b/crates/fluss/src/error.rs
@@ -112,6 +112,15 @@ pub enum Error {
 /// These create `FlussAPIError` with the correct protocol error code,
 /// consistent with Java where e.g. `InvalidTableException` always carries code 15.
 impl Error {
+    pub fn table_not_exist(message: impl Into<String>) -> Self {
+        Error::FlussAPIError {
+            api_error: ApiError {
+                code: FlussError::TableNotExist.code(),
+                message: message.into(),
+            },
+        }
+    }
+
     pub fn invalid_table(message: impl Into<String>) -> Self {
         Error::FlussAPIError {
             api_error: ApiError {


### PR DESCRIPTION
### Brief change log

- Fix API error not being propagated on python side
- Fix TableNotExist not being thrown from get_table (rust client does not have an additional get table call like java)

### Tests

- Tested correct API error code surfaced using manual python test
- Integration test runs
