### PR TITLE
chore: default cpp builds to release mode

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(Threads REQUIRED)
 find_package(Arrow REQUIRED)
 
 if (NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Debug)
+    set(CMAKE_BUILD_TYPE Release)
 endif()
 
 set(CMAKE_CXX_STANDARD 17)

--- a/bindings/cpp/README.md
+++ b/bindings/cpp/README.md
@@ -22,12 +22,15 @@ cmake ..
 cmake --build .
 ```
 
+By default, CMake now uses `Release` when `CMAKE_BUILD_TYPE` is not specified.
+
 **With Bazel:**
 
 ```bash
 cd bindings/cpp
 bazel build //...
 ```
+`ci.sh` defaults to optimized builds via `-c opt` (override with `BAZEL_BUILD_FLAGS` if needed).
 See [ci.sh](ci.sh) for the CI build sequence.
 
 

--- a/bindings/cpp/ci.sh
+++ b/bindings/cpp/ci.sh
@@ -19,6 +19,7 @@
 set -xe 
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+BAZEL_BUILD_FLAGS="${BAZEL_BUILD_FLAGS:--c opt}"
 
 # Set Bazel output base to bazel-build directory
 # This ensures all Bazel outputs are in bazel-build/.bazel-output-base
@@ -33,16 +34,16 @@ bazel() {
 }
 
 compile() {
-    bazel build //:fluss_cpp
+    bazel build ${BAZEL_BUILD_FLAGS} //:fluss_cpp
 }
 
 build_example() {
-    bazel build //:fluss_cpp_example
+    bazel build ${BAZEL_BUILD_FLAGS} //:fluss_cpp_example
 }
 
 run_example() {
     build_example
-    bazel run //:fluss_cpp_example
+    bazel run ${BAZEL_BUILD_FLAGS} //:fluss_cpp_example
 }
 
 clean() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss-rust/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose
<!-- What is the purpose of the change -->
Switch C++ default build mode to `Release`. Debug builds place extra checks and unoptimized code on the hot path. For the scanner workload used in our backfill AB, this significantly reduces throughput and can hide the true effect of other optimizations.
### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests
- Fixed workload(Our Internal index building scenarios, project ratio: 19/774):
  - `./custom-consume-table -- --task LdsHomeFeedQH --hours-ago 10 --bucket-mode range --max-buckets 4`
  - `timeout 180s` per run
- Reduction method:
  - Per run: positive `[Progress] throughput=... r/s` samples

| Factor | throughput (r/s) |
|---|---:|
| release (B0) | 26488.08 |
| debug (F1) | 14743.43 |

- `release` vs `debug`: **+79.66%** throughput (`~1.80x`)
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
