### PR TITLE
chore: make RowView shared_ptr

### DIFF
--- a/website/docs/user-guide/cpp/api-reference.md
+++ b/website/docs/user-guide/cpp/api-reference.md
@@ -203,10 +203,10 @@ When using `table.NewRow()`, the `Set()` method auto-routes to the correct type 
 
 ## `RowView`
 
-Read-only row view for scan results. Provides zero-copy access to string and bytes data.
+Read-only row view for scan results. Provides zero-copy access to string and bytes data. `RowView` shares ownership of the underlying scan data via reference counting, so it can safely outlive the `ScanRecords` that produced it.
 
-:::warning Lifetime
-`RowView` borrows from `ScanRecords`. It must not outlive the `ScanRecords` that produced it (similar to `std::string_view` borrowing from `std::string`).
+:::note string_view Lifetime
+`GetString()` returns `std::string_view` that borrows from the underlying data. The `string_view` is valid as long as any `RowView` (or `ScanRecord`) referencing the same poll result is alive. Copy to `std::string` if you need the value after all references are gone.
 :::
 
 ### Index-Based Getters
@@ -248,9 +248,7 @@ Read-only row view for scan results. Provides zero-copy access to string and byt
 
 ## `ScanRecord`
 
-:::warning Lifetime
-`ScanRecord` contains a `RowView` that borrows from `ScanRecords`. It must not outlive the `ScanRecords` that produced it.
-:::
+`ScanRecord` is a value type that can be freely copied, stored, and accumulated across multiple `Poll()` calls. It shares ownership of the underlying scan data via reference counting.
 
 | Field          | Type                    |  Description                     |
 |----------------|-------------------------|----------------------------------|

--- a/website/docs/user-guide/cpp/example/log-tables.md
+++ b/website/docs/user-guide/cpp/example/log-tables.md
@@ -62,6 +62,34 @@ for (const auto& rec : records) {
 }
 ```
 
+**Continuous polling:**
+
+```cpp
+while (running) {
+    fluss::ScanRecords records;
+    scanner.Poll(1000, records);
+    for (const auto& rec : records) {
+        process(rec);
+    }
+}
+```
+
+**Accumulating records across polls:**
+
+`ScanRecord` is a value type — it can be freely copied, stored, and accumulated. The underlying data stays alive via reference counting (zero-copy).
+
+```cpp
+std::vector<fluss::ScanRecord> all_records;
+while (all_records.size() < 1000) {
+    fluss::ScanRecords records;
+    scanner.Poll(1000, records);
+    for (const auto& rec : records) {
+        all_records.push_back(rec);  // ref-counted, no data copy
+    }
+}
+// all_records is valid — each record keeps its data alive
+```
+
 **Batch subscribe:**
 
 ```cpp


### PR DESCRIPTION
## Summary

ScanRecord in C++ held a raw pointer to the underlying scan data, making it a borrowed view that dangled when ScanRecords was destroyed. Users couldn't store or accumulate records across Poll() calls, unlike Rust (Arc<RecordBatch>)  where records are self-contained.                    
                                                                                                                                                                                                                                                     
 Fixed by wrapping the opaque ScanResultInner in shared_ptr with a custom deleter that calls rust::Box::from_raw(). ScanRecord is now a value type: copyable, storable, safe to accumulate. Zero-copy preserved (same FFI pointer path), no Rust-side changes needed.

Updated docs to replace borrowing warnings with value-type semantics and added an accumulation example to log-tables guide.
