### PR TITLE
chore: update testing fluss image to 0.9.0

### DIFF
--- a/bindings/cpp/test/test_utils.h
+++ b/bindings/cpp/test/test_utils.h
@@ -50,7 +50,7 @@
 namespace fluss_test {
 
 static constexpr const char* kFlussImage = "apache/fluss";
-static constexpr const char* kFlussVersion = "0.8.0-incubating";
+static constexpr const char* kFlussVersion = "0.9.0-incubating";
 static constexpr const char* kNetworkName = "fluss-cpp-test-network";
 static constexpr const char* kZookeeperName = "zookeeper-cpp-test";
 static constexpr const char* kCoordinatorName = "coordinator-server-cpp-test";

--- a/bindings/python/test/conftest.py
+++ b/bindings/python/test/conftest.py
@@ -34,7 +34,7 @@ import pytest_asyncio
 import fluss
 
 FLUSS_IMAGE = "apache/fluss"
-FLUSS_VERSION = "0.8.0-incubating"
+FLUSS_VERSION = "0.9.0-incubating"
 BOOTSTRAP_SERVERS_ENV = os.environ.get("FLUSS_BOOTSTRAP_SERVERS")
 
 

--- a/crates/fluss/tests/integration/fluss_cluster.rs
+++ b/crates/fluss/tests/integration/fluss_cluster.rs
@@ -25,7 +25,7 @@ use testcontainers::core::ContainerPort;
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage, ImageExt};
 
-const FLUSS_VERSION: &str = "0.8.0-incubating";
+const FLUSS_VERSION: &str = "0.9.0-incubating";
 const FLUSS_IMAGE: &str = "apache/fluss";
 
 pub struct FlussTestingClusterBuilder {


### PR DESCRIPTION
Fixes #425

## Summary
Updates the Fluss Docker image version used in integration tests from **0.8.0-incubating** to **0.9.0-incubating** across all language bindings (Rust, Python, C++).

## Changes
- **Rust:** `crates/fluss/tests/integration/fluss_cluster.rs`
  - `FLUSS_VERSION: "0.8.0-incubating" → "0.9.0-incubating"`
  
- **Python:** `bindings/python/test/conftest.py`
  - `FLUSS_VERSION = "0.8.0-incubating" → "0.9.0-incubating"`
  
- **C++:** `bindings/cpp/test/test_utils.h`
  - `kFlussVersion = "0.8.0-incubating" → "0.9.0-incubating"`

## Why
- Ensures tests run against the latest Fluss release (0.9.0)
- Aligns with the current project version
- Keeps test infrastructure up-to-date

## Testing
✅ All version strings updated consistently across bindings
✅ No other references to 0.8.0 in test configuration