### PR TITLE
Remove config duplication in examples

### DIFF
--- a/website/docs/user-guide/cpp/example/configuration.md
+++ b/website/docs/user-guide/cpp/example/configuration.md
@@ -23,21 +23,7 @@ if (!result.Ok()) {
 
 All fields have sensible defaults. Only `bootstrap_servers` typically needs to be set.
 
-```cpp
-fluss::Configuration config;
-config.bootstrap_servers = "127.0.0.1:9123";                  // Coordinator address
-config.writer_request_max_size = 10 * 1024 * 1024;            // Max request size (10 MB)
-config.writer_acks = "all";                                    // Wait for all replicas
-config.writer_retries = std::numeric_limits<int32_t>::max();   // Retry on failure
-config.writer_batch_size = 2 * 1024 * 1024;                   // Batch size (2 MB)
-config.writer_batch_timeout_ms = 100;                          // Max time to wait for a batch to fill
-config.writer_bucket_no_key_assigner = "sticky";               // "sticky" or "round_robin"
-config.scanner_remote_log_prefetch_num = 4;                    // Remote log prefetch count
-config.remote_file_download_thread_num = 3;                    // Download threads
-config.scanner_remote_log_read_concurrency = 4;                // In-file remote log read concurrency
-config.scanner_log_max_poll_records = 500;                     // Max records per poll
-config.connect_timeout_ms = 120000;                            // TCP connect timeout (ms)
-```
+See the [`Configuration`](../api-reference.md#configuration) section in the API Reference for the full list of configuration fields, types, and defaults.
 
 ## SASL Authentication
 

--- a/website/docs/user-guide/python/api-reference.md
+++ b/website/docs/user-guide/python/api-reference.md
@@ -7,25 +7,25 @@ Complete API reference for the Fluss Python client.
 
 ## `Config`
 
-| Method / Property                     | Description                                                                             |
-|---------------------------------------|-----------------------------------------------------------------------------------------|
-| `Config(properties: dict = None)`     | Create config from a dict of key-value pairs                                            |
-| `bootstrap_servers`                   | Get/set coordinator server address                                                      |
-| `writer_request_max_size`             | Get/set max request size in bytes                                                       |
-| `writer_acks`                         | Get/set acknowledgment setting (`"all"` for all replicas)                               |
-| `writer_retries`                      | Get/set number of retries on failure                                                    |
-| `writer_batch_size`                   | Get/set write batch size in bytes                                                       |
-| `writer_batch_timeout_ms`             | Get/set max time in ms to wait for a writer batch to fill up before sending             |
-| `writer.bucket.no-key-assigner`       | Bucket assignment strategy (`"sticky"` or `"round_robin"`); set via `Config(dict)` only |
-| `scanner_remote_log_prefetch_num`     | Get/set number of remote log segments to prefetch                                       |
-| `remote_file_download_thread_num`     | Get/set number of threads for remote log downloads                                      |
-| `scanner_remote_log_read_concurrency` | Get/set streaming read concurrency within a remote log file                             |
-| `scanner_log_max_poll_records`        | Get/set max number of records returned in a single poll()                               |
-| `connect_timeout_ms`                  | Get/set TCP connect timeout in milliseconds                                             |
-| `security_protocol`                   | Get/set security protocol (`"PLAINTEXT"` or `"sasl"`)                                   |
-| `security_sasl_mechanism`             | Get/set SASL mechanism (only `"PLAIN"` is supported)                                    |
-| `security_sasl_username`              | Get/set SASL username (required when protocol is `"sasl"`)                              |
-| `security_sasl_password`              | Get/set SASL password (required when protocol is `"sasl"`)                              |
+| Method / Property                     | Config Key                            | Description                                                                             |
+|---------------------------------------|---------------------------------------|-----------------------------------------------------------------------------------------|
+| `Config(properties: dict = None)`     |                                       | Create config from a dict of key-value pairs                                            |
+| `bootstrap_servers`                   | `bootstrap.servers`                   | Get/set coordinator server address                                                      |
+| `writer_request_max_size`             | `writer.request-max-size`             | Get/set max request size in bytes                                                       |
+| `writer_acks`                         | `writer.acks`                         | Get/set acknowledgment setting (`"all"` for all replicas)                               |
+| `writer_retries`                      | `writer.retries`                      | Get/set number of retries on failure                                                    |
+| `writer_batch_size`                   | `writer.batch-size`                   | Get/set write batch size in bytes                                                       |
+| `writer_batch_timeout_ms`             | `writer.batch-timeout-ms`             | Get/set max time in ms to wait for a writer batch to fill up before sending             |
+| `writer_bucket_no_key_assigner`       | `writer.bucket.no-key-assigner`       | Get/set bucket assignment strategy (`"sticky"` or `"round_robin"`)                      |
+| `scanner_remote_log_prefetch_num`     | `scanner.remote-log.prefetch-num`     | Get/set number of remote log segments to prefetch                                       |
+| `remote_file_download_thread_num`     | `remote-file.download-thread-num`     | Get/set number of threads for remote log downloads                                      |
+| `scanner_remote_log_read_concurrency` | `scanner.remote-log.read-concurrency` | Get/set streaming read concurrency within a remote log file                             |
+| `scanner_log_max_poll_records`        | `scanner.log.max-poll-records`        | Get/set max number of records returned in a single poll()                               |
+| `connect_timeout_ms`                  | `connect-timeout`                     | Get/set TCP connect timeout in milliseconds                                             |
+| `security_protocol`                   | `security.protocol`                   | Get/set security protocol (`"PLAINTEXT"` or `"sasl"`)                                   |
+| `security_sasl_mechanism`             | `security.sasl.mechanism`             | Get/set SASL mechanism (only `"PLAIN"` is supported)                                    |
+| `security_sasl_username`              | `security.sasl.username`              | Get/set SASL username (required when protocol is `"sasl"`)                              |
+| `security_sasl_password`              | `security.sasl.password`              | Get/set SASL password (required when protocol is `"sasl"`)                              |
 
 ## `FlussConnection`
 

--- a/website/docs/user-guide/python/example/configuration.md
+++ b/website/docs/user-guide/python/example/configuration.md
@@ -21,24 +21,9 @@ with await fluss.FlussConnection.create(config) as conn:
 
 ## Connection Configurations
 
-| Key                                   | Description                                                                           | Default            |
-|---------------------------------------|---------------------------------------------------------------------------------------|--------------------|
-| `bootstrap.servers`                   | Coordinator server address                                                            | `127.0.0.1:9123`   |
-| `writer.request-max-size`             | Maximum request size in bytes                                                         | `10485760` (10 MB) |
-| `writer.acks`                         | Acknowledgment setting (`all` waits for all replicas)                                 | `all`              |
-| `writer.retries`                      | Number of retries on failure                                                          | `2147483647`       |
-| `writer.batch-size`                   | Batch size for writes in bytes                                                        | `2097152` (2 MB)   |
-| `writer.batch-timeout-ms`             | The maximum time to wait for a writer batch to fill up before sending.                | `100`              |
-| `writer.bucket.no-key-assigner`       | Bucket assignment strategy for tables without bucket keys: `sticky` or `round_robin`  | `sticky`           |
-| `scanner.remote-log.prefetch-num`     | Number of remote log segments to prefetch                                             | `4`                |
-| `remote-file.download-thread-num`     | Number of threads for remote log downloads                                            | `3`                |
-| `scanner.remote-log.read-concurrency` | Streaming read concurrency within a remote log file                                   | `4`                |
-| `scanner.log.max-poll-records`        | Max records returned in a single poll()                                               | `500`              |
-| `connect-timeout`                     | TCP connect timeout in milliseconds                                                   | `120000`           |
-| `security.protocol`                   | `PLAINTEXT` (default) or `sasl` for SASL auth                                        | `PLAINTEXT`        |
-| `security.sasl.mechanism`             | SASL mechanism (only `PLAIN` is supported)                                            | `PLAIN`            |
-| `security.sasl.username`              | SASL username (required when protocol is `sasl`)                                      | (empty)            |
-| `security.sasl.password`              | SASL password (required when protocol is `sasl`)                                      | (empty)            |
+Configuration options can be set either via dict keys in the `Config()` constructor, or via Python property setters.
+
+See the [`Config`](../api-reference.md#config) section in the API Reference for the full list of options, their config keys, and descriptions.
 
 ## SASL Authentication
 

--- a/website/docs/user-guide/rust/example/configuration.md
+++ b/website/docs/user-guide/rust/example/configuration.md
@@ -17,24 +17,7 @@ let conn = FlussConnection::new(config).await?;
 
 ## Connection Configurations
 
-| Option                                | Description                                                                          | Default          |
-|---------------------------------------|--------------------------------------------------------------------------------------|------------------|
-| `bootstrap_servers`                   | Coordinator server address                                                           | `127.0.0.1:9123` |
-| `writer_request_max_size`             | Maximum request size in bytes                                                        | 10 MB            |
-| `writer_acks`                         | Acknowledgment setting (`all` waits for all replicas)                                | `all`            |
-| `writer_retries`                      | Number of retries on failure                                                         | `i32::MAX`       |
-| `writer_batch_size`                   | Batch size for writes                                                                | 2 MB             |
-| `writer_batch_timeout_ms`             | The maximum time to wait for a writer batch to fill up before sending.               | `100`            |
-| `writer_bucket_no_key_assigner`       | Bucket assignment strategy for tables without bucket keys: `sticky` or `round_robin` | `sticky`         |
-| `scanner_remote_log_prefetch_num`     | Number of remote log segments to prefetch                                            | `4`              |
-| `remote_file_download_thread_num`     | Number of concurrent remote log file downloads                                       | `3`              |
-| `scanner_remote_log_read_concurrency` | Streaming read concurrency within a remote log file                                  | `4`              |
-| `scanner_log_max_poll_records`        | Maximum records returned in a single `poll()`                                        | `500`            |
-| `connect_timeout_ms`                  | TCP connect timeout in milliseconds                                                  | 120000           |
-| `security_protocol`                   | `PLAINTEXT` (default) or `sasl` for SASL auth                                       | `PLAINTEXT`      |
-| `security_sasl_mechanism`             | SASL mechanism (only `PLAIN` is supported)                                           | `PLAIN`          |
-| `security_sasl_username`              | SASL username (required when protocol is `sasl`)                                     | (empty)          |
-| `security_sasl_password`              | SASL password (required when protocol is `sasl`)                                     | (empty)          |
+See the [`Config`](../api-reference.md#config) section in the API Reference for the full list of configuration options, types, and defaults.
 
 ## SASL Authentication
 


### PR DESCRIPTION
### Purpose

Linked issue: close #423 

<!-- What is the purpose of the change -->

### Brief change log

Replace duplicated config option tables in configuration.md in examples/ with cross-references to the authoritative tables in api-reference.md

### Tests

No

