### PR TITLE
[config] Add validation for numeric config fields

### DIFF
--- a/crates/fluss/src/client/connection.rs
+++ b/crates/fluss/src/client/connection.rs
@@ -47,6 +47,8 @@ impl FlussConnection {
             .map_err(|msg| Error::IllegalArgument { message: msg })?;
 
         let timeout = Duration::from_millis(arg.connect_timeout_ms);
+        // connect_timeout_ms: no lower-bound validation to match Java behavior.
+        // Java allows 0 — tracked in https://github.com/apache/fluss/issues/3068
         let connections = if arg.is_sasl_enabled() {
             Arc::new(
                 RpcClient::new()

--- a/crates/fluss/src/client/connection.rs
+++ b/crates/fluss/src/client/connection.rs
@@ -41,7 +41,9 @@ impl FlussConnection {
     pub async fn new(arg: Config) -> Result<Self> {
         arg.validate_security()
             .map_err(|msg| Error::IllegalArgument { message: msg })?;
-        arg.validate_scanner_fetch()
+        arg.validate_scanner()
+            .map_err(|msg| Error::IllegalArgument { message: msg })?;
+        arg.validate_writer()
             .map_err(|msg| Error::IllegalArgument { message: msg })?;
 
         let timeout = Duration::from_millis(arg.connect_timeout_ms);

--- a/crates/fluss/src/client/table/remote_log.rs
+++ b/crates/fluss/src/client/table/remote_log.rs
@@ -778,7 +778,7 @@ impl RemoteLogDownloader {
         let fetcher = Arc::new(ProductionFetcher {
             credentials_rx,
             local_log_dir: Arc::new(local_log_dir),
-            remote_log_read_concurrency: remote_log_read_concurrency.max(1),
+            remote_log_read_concurrency,
         });
 
         Self::new_with_fetcher(fetcher, max_prefetch_segments, max_concurrent_downloads)

--- a/crates/fluss/src/client/write/writer_client.rs
+++ b/crates/fluss/src/client/write/writer_client.rs
@@ -54,10 +54,6 @@ impl WriterClient {
     pub fn new(config: Config, metadata: Arc<Metadata>) -> Result<Self> {
         let ack = Self::get_ack(&config)?;
 
-        config
-            .validate_idempotence()
-            .map_err(|message| Error::IllegalArgument { message })?;
-
         let idempotence_manager = Arc::new(IdempotenceManager::new(
             config.writer_enable_idempotence,
             config.writer_max_inflight_requests_per_bucket,

--- a/crates/fluss/src/config.rs
+++ b/crates/fluss/src/config.rs
@@ -308,7 +308,6 @@ impl Config {
     /// consistent, or an error message when idempotence is enabled but other
     /// settings are incompatible.
 
-
     /// Validates security configuration. Returns `Ok(())` when the config is
     /// consistent, or an error message when SASL is enabled but the config is
     /// incomplete or uses an unsupported mechanism.
@@ -344,6 +343,8 @@ impl Config {
         if self.remote_file_download_thread_num == 0 {
             return Err("remote_file_download_thread_num must be > 0".to_string());
         }
+        // scanner_log_max_poll_records: validation intentionally omitted to match Java behavior.
+        // Java allows 0 — tracked in https://github.com/apache/fluss/issues/3068
         if self.scanner_log_fetch_min_bytes <= 0 {
             return Err("scanner_log_fetch_min_bytes must be > 0".to_string());
         }

--- a/crates/fluss/src/config.rs
+++ b/crates/fluss/src/config.rs
@@ -361,7 +361,16 @@ impl Config {
         }
         Ok(())
     }
-    pub fn validate_scanner_fetch(&self) -> Result<(), String> {
+    pub fn validate_scanner(&self) -> Result<(), String> {
+        if self.scanner_remote_log_prefetch_num == 0 {
+            return Err("scanner_remote_log_prefetch_num must be > 0".to_string());
+        }
+        if self.scanner_remote_log_read_concurrency == 0 {
+            return Err("scanner_remote_log_read_concurrency must be > 0".to_string());
+        }
+        if self.remote_file_download_thread_num == 0 {
+            return Err("remote_file_download_thread_num must be > 0".to_string());
+        }
         if self.scanner_log_fetch_min_bytes <= 0 {
             return Err("scanner_log_fetch_min_bytes must be > 0".to_string());
         }
@@ -384,6 +393,57 @@ impl Config {
                 "scanner_log_fetch_max_bytes_for_bucket must be <= scanner_log_fetch_max_bytes"
                     .to_string(),
             );
+        }
+        Ok(())
+    }
+
+    pub fn validate_writer(&self) -> Result<(), String> {
+        if self.writer_request_max_size <= 0 {
+            return Err("writer_request_max_size must be > 0".to_string());
+        }
+        if self.writer_batch_size <= 0 {
+            return Err("writer_batch_size must be > 0".to_string());
+        }
+        if self.writer_batch_timeout_ms < 0 {
+            return Err("writer_batch_timeout_ms must be >= 0".to_string());
+        }
+        if self.writer_max_inflight_requests_per_bucket == 0 {
+            return Err("writer_max_inflight_requests_per_bucket must be > 0".to_string());
+        }
+        if self.writer_buffer_memory_size == 0 {
+            return Err("writer_buffer_memory_size must be > 0".to_string());
+        }
+        if self.writer_batch_size > self.writer_request_max_size {
+            return Err("writer_batch_size must be <= writer_request_max_size".to_string());
+        }
+        if self.writer_batch_size as usize > self.writer_buffer_memory_size {
+            return Err("writer_batch_size must be <= writer_buffer_memory_size".to_string());
+        }
+        // idempotence checks
+        if !self.writer_enable_idempotence {
+            return Ok(());
+        }
+        let acks_is_all = self.writer_acks.eq_ignore_ascii_case("all") || self.writer_acks == "-1";
+        if !acks_is_all {
+            return Err(format!(
+                "Idempotent writes require acks='all' (-1), but got acks='{}'",
+                self.writer_acks
+            ));
+        }
+        if self.writer_retries <= 0 {
+            return Err(format!(
+                "Idempotent writes require retries > 0, but got retries={}",
+                self.writer_retries
+            ));
+        }
+        if self.writer_max_inflight_requests_per_bucket
+            > MAX_IN_FLIGHT_REQUESTS_PER_BUCKET_FOR_IDEMPOTENCE
+        {
+            return Err(format!(
+                "Idempotent writes require max-inflight-requests-per-bucket <= {}, but got {}",
+                MAX_IN_FLIGHT_REQUESTS_PER_BUCKET_FOR_IDEMPOTENCE,
+                self.writer_max_inflight_requests_per_bucket
+            ));
         }
         Ok(())
     }
@@ -456,13 +516,38 @@ mod tests {
         };
         assert!(config.validate_security().is_err());
     }
+
     #[test]
-    fn test_scanner_fetch_defaults_valid() {
+    fn test_scanner_defaults_valid() {
         let config = Config::default();
-        assert!(config.validate_scanner_fetch().is_ok());
-        assert_eq!(config.scanner_log_fetch_max_bytes, 16 * 1024 * 1024);
-        assert_eq!(config.scanner_log_fetch_min_bytes, 1);
-        assert_eq!(config.scanner_log_fetch_wait_max_time_ms, 500);
+        assert!(config.validate_scanner().is_ok());
+    }
+
+    #[test]
+    fn test_scanner_remote_log_prefetch_num_zero() {
+        let config = Config {
+            scanner_remote_log_prefetch_num: 0,
+            ..Config::default()
+        };
+        assert!(config.validate_scanner().is_err());
+    }
+
+    #[test]
+    fn test_scanner_remote_log_read_concurrency_zero() {
+        let config = Config {
+            scanner_remote_log_read_concurrency: 0,
+            ..Config::default()
+        };
+        assert!(config.validate_scanner().is_err());
+    }
+
+    #[test]
+    fn test_remote_file_download_thread_num_zero() {
+        let config = Config {
+            remote_file_download_thread_num: 0,
+            ..Config::default()
+        };
+        assert!(config.validate_scanner().is_err());
     }
 
     #[test]
@@ -472,7 +557,7 @@ mod tests {
             scanner_log_fetch_max_bytes: 1,
             ..Config::default()
         };
-        assert!(config.validate_scanner_fetch().is_err());
+        assert!(config.validate_scanner().is_err());
     }
 
     #[test]
@@ -481,13 +566,78 @@ mod tests {
             scanner_log_fetch_wait_max_time_ms: -1,
             ..Config::default()
         };
-        assert!(config.validate_scanner_fetch().is_err());
+        assert!(config.validate_scanner().is_err());
     }
 
     #[test]
-    fn test_idempotence_default_is_valid() {
+    fn test_writer_defaults_valid() {
         let config = Config::default();
-        assert!(config.validate_idempotence().is_ok());
+        assert!(config.validate_writer().is_ok());
+    }
+
+    #[test]
+    fn test_writer_request_max_size_zero() {
+        let config = Config {
+            writer_request_max_size: 0,
+            ..Config::default()
+        };
+        assert!(config.validate_writer().is_err());
+    }
+
+    #[test]
+    fn test_writer_batch_size_zero() {
+        let config = Config {
+            writer_batch_size: 0,
+            ..Config::default()
+        };
+        assert!(config.validate_writer().is_err());
+    }
+
+    #[test]
+    fn test_writer_batch_timeout_negative() {
+        let config = Config {
+            writer_batch_timeout_ms: -1,
+            ..Config::default()
+        };
+        assert!(config.validate_writer().is_err());
+    }
+
+    #[test]
+    fn test_writer_max_inflight_requests_per_bucket_zero() {
+        let config = Config {
+            writer_max_inflight_requests_per_bucket: 0,
+            ..Config::default()
+        };
+        assert!(config.validate_writer().is_err());
+    }
+
+    #[test]
+    fn test_writer_buffer_memory_size_zero() {
+        let config = Config {
+            writer_buffer_memory_size: 0,
+            ..Config::default()
+        };
+        assert!(config.validate_writer().is_err());
+    }
+
+    #[test]
+    fn test_writer_batch_size_exceeds_request_max_size() {
+        let config = Config {
+            writer_batch_size: 20 * 1024 * 1024,
+            writer_request_max_size: 10 * 1024 * 1024,
+            ..Config::default()
+        };
+        assert!(config.validate_writer().is_err());
+    }
+
+    #[test]
+    fn test_writer_batch_size_exceeds_buffer_memory_size() {
+        let config = Config {
+            writer_batch_size: 128 * 1024 * 1024,
+            writer_buffer_memory_size: 64 * 1024 * 1024,
+            ..Config::default()
+        };
+        assert!(config.validate_writer().is_err());
     }
 
     #[test]
@@ -499,7 +649,7 @@ mod tests {
             writer_max_inflight_requests_per_bucket: 100,
             ..Config::default()
         };
-        assert!(config.validate_idempotence().is_ok());
+        assert!(config.validate_writer().is_ok());
     }
 
     #[test]
@@ -509,7 +659,7 @@ mod tests {
             writer_acks: "1".to_string(),
             ..Config::default()
         };
-        assert!(config.validate_idempotence().is_err());
+        assert!(config.validate_writer().is_err());
     }
 
     #[test]
@@ -519,7 +669,7 @@ mod tests {
             writer_retries: 0,
             ..Config::default()
         };
-        assert!(config.validate_idempotence().is_err());
+        assert!(config.validate_writer().is_err());
     }
 
     #[test]
@@ -529,6 +679,6 @@ mod tests {
             writer_max_inflight_requests_per_bucket: 10,
             ..Config::default()
         };
-        assert!(config.validate_idempotence().is_err());
+        assert!(config.validate_writer().is_err());
     }
 }

--- a/crates/fluss/src/config.rs
+++ b/crates/fluss/src/config.rs
@@ -307,34 +307,7 @@ impl Config {
     /// Validates idempotence configuration. Returns `Ok(())` when the config is
     /// consistent, or an error message when idempotence is enabled but other
     /// settings are incompatible.
-    pub fn validate_idempotence(&self) -> Result<(), String> {
-        if !self.writer_enable_idempotence {
-            return Ok(());
-        }
-        let acks_is_all = self.writer_acks.eq_ignore_ascii_case("all") || self.writer_acks == "-1";
-        if !acks_is_all {
-            return Err(format!(
-                "Idempotent writes require acks='all' (-1), but got acks='{}'",
-                self.writer_acks
-            ));
-        }
-        if self.writer_retries <= 0 {
-            return Err(format!(
-                "Idempotent writes require retries > 0, but got retries={}",
-                self.writer_retries
-            ));
-        }
-        if self.writer_max_inflight_requests_per_bucket
-            > MAX_IN_FLIGHT_REQUESTS_PER_BUCKET_FOR_IDEMPOTENCE
-        {
-            return Err(format!(
-                "Idempotent writes require max-inflight-requests-per-bucket <= {}, but got {}",
-                MAX_IN_FLIGHT_REQUESTS_PER_BUCKET_FOR_IDEMPOTENCE,
-                self.writer_max_inflight_requests_per_bucket
-            ));
-        }
-        Ok(())
-    }
+
 
     /// Validates security configuration. Returns `Ok(())` when the config is
     /// consistent, or an error message when SASL is enabled but the config is

--- a/crates/fluss/src/config.rs
+++ b/crates/fluss/src/config.rs
@@ -303,11 +303,6 @@ impl Config {
     pub fn is_sasl_enabled(&self) -> bool {
         self.security_protocol.eq_ignore_ascii_case("sasl")
     }
-
-    /// Validates idempotence configuration. Returns `Ok(())` when the config is
-    /// consistent, or an error message when idempotence is enabled but other
-    /// settings are incompatible.
-
     /// Validates security configuration. Returns `Ok(())` when the config is
     /// consistent, or an error message when SASL is enabled but the config is
     /// incomplete or uses an unsupported mechanism.


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss-rust/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #385

<!-- What is the purpose of the change -->
Add a `validate_numeric_fields()` method to `Config` that validates all numeric fields have sensible values (e.g. sizes > 0, timeouts >= 0). Validation is called during `FlussConnection::new()` alongside the existing `validate_security()` and `validate_scanner_fetch()` checks.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
- Added `validate_numeric_fields()` in `config.rs` covering 10 numeric fields
- Called `validate_numeric_fields()` in `FlussConnection::new()` in `connection.rs`
- Added 11 unit tests covering default validity and each invalid case
### Tests

<!-- List UT and IT cases to verify this change -->
cargo fmt --all
cargo clippy -p fluss-rs --all-features
cargo test -p fluss-rs
### API and Format

<!-- Does this change affect API or storage format -->
API: No breaking changes
Storage format: No
### Documentation

<!-- Does this change introduce a new feature -->
No doc changes needed.