### PR TITLE
[BUG] Stale cluster state in Lookuper lookup

### DIFF
--- a/crates/fluss/src/client/table/lookup.rs
+++ b/crates/fluss/src/client/table/lookup.rs
@@ -292,7 +292,6 @@ impl Lookuper {
         let table_bucket = TableBucket::new_with_partition(table_id, partition_id, bucket_id);
 
         // Find the leader for this bucket
-        let cluster = self.metadata.get_cluster();
         let leader = self
             .metadata
             .leader_for(self.table_path.as_ref(), &table_bucket)
@@ -303,15 +302,7 @@ impl Lookuper {
                 ))
             })?;
 
-        // Get connection to the tablet server
-        let tablet_server = cluster.get_tablet_server(leader.id()).ok_or_else(|| {
-            Error::leader_not_available(format!(
-                "Tablet server {} is not found in metadata cache",
-                leader.id()
-            ))
-        })?;
-
-        let connection = self.rpc_client.get_connection(tablet_server).await?;
+        let connection = self.rpc_client.get_connection(&leader).await?;
 
         // Send lookup request
         let request = LookupRequest::new(table_id, partition_id, bucket_id, vec![pk_bytes_vec]);


### PR DESCRIPTION
`Lookuper::lookup()` captures a cluster state before calling `leader_for()`, then uses that state to resolve the leader's server. If `leader_for()` refreshed metadata internally (cache miss -> coordinator RPC), the returned leader could reference a server absent from the stale state, causing a spurious "server not found" error during leader transitions.

Proposed fix: connect to the ServerNode returned by `leader_for()` directly as it already contains host and port. 
Removes the redundant cluster state lookup and the race entirely.