### PR TITLE
ci: pin astral-sh/setup-uv to SHA for ASF allowlist compliance

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler


### PR DESCRIPTION
## Summary
- Pin `astral-sh/setup-uv` from `@v4` to commit SHA `e06108dd0aef18192324c70427afc47652e63a82` (v7.5.0) to comply with the ASF GitHub Actions allowlist policy
- This fixes CI workflow start failures where the action was blocked by the org-level allowlist

Closes #453

## Test plan
- [ ] Verify Python CI workflow starts successfully after the SHA is added to the ASF allowlist via an INFRA Jira ticket