### PR TITLE
chore: Pin setup-uv action to commit SHA

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v4
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler


### PR DESCRIPTION
## Summary
- Pin `astral-sh/setup-uv` from mutable `v4` tag to commit SHA `37802adc94f370d6bfd71619e3f0bf239e1f3b78` for supply chain security

## Test plan
- [ ] Verify Python build and test workflow passes with the pinned action

🤖 Generated with [Claude Code](https://claude.com/claude-code)