### PR TITLE
fix: add missing write_array impl to IcebergBinaryRowWriter

### DIFF
--- a/crates/fluss/src/row/binary/iceberg_binary_row_writer.rs
+++ b/crates/fluss/src/row/binary/iceberg_binary_row_writer.rs
@@ -225,6 +225,10 @@ impl BinaryWriter for IcebergBinaryRowWriter {
         self.write_raw(&micros.to_le_bytes());
     }
 
+    fn write_array(&mut self, _value: &[u8]) {
+        panic!("Iceberg key columns do not support array values");
+    }
+
     fn complete(&mut self) {
         // No finalization needed for Iceberg key encoding
     }


### PR DESCRIPTION
## Summary
- The `BinaryWriter` trait gained a `write_array` method (from the array data type support PR #433), but `IcebergBinaryRowWriter` was not updated, causing a build failure on main.
- Added the missing `write_array` implementation that panics with a clear message, since array values are unsupported as Iceberg bucket keys (consistent with `set_null_at` and the existing `create_value_writer` rejection).

## Test plan
- [x] `cargo build --workspace --all-targets` passes
- [x] `cargo test --workspace` — all 312 unit tests pass