### PR TITLE
chore: skip duplicate pyfluss build in Python CI

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build Python bindings
         working-directory: bindings/python
         run: |
-          uv sync --extra dev
+          uv sync --extra dev --no-install-project
           uv run maturin develop
 
       - name: Run Python integration tests (parallel)


### PR DESCRIPTION
## Summary
closes #481

uv sync builds pyfluss from source, then maturin develop rebuilds it. 
Adding --no-install-project so only maturin develop compiles the Rust extension.