### PR TITLE
[ci] use swatinem/rust-cache

### DIFF
--- a/.github/workflows/build_and_test_cpp.yml
+++ b/.github/workflows/build_and_test_cpp.yml
@@ -58,7 +58,7 @@ jobs:
           sudo apt-get install -y -V libarrow-dev
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build fluss-test-cluster binary
         run: cargo build -p fluss-test-cluster

--- a/.github/workflows/build_and_test_cpp.yml
+++ b/.github/workflows/build_and_test_cpp.yml
@@ -58,15 +58,7 @@ jobs:
           sudo apt-get install -y -V libarrow-dev
 
       - name: Rust Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cpp-test-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cpp-test-${{ runner.os }}-
+        uses: Swatinem/rust-cache@v2
 
       - name: Build fluss-test-cluster binary
         run: cargo build -p fluss-test-cluster

--- a/.github/workflows/build_and_test_cpp.yml
+++ b/.github/workflows/build_and_test_cpp.yml
@@ -58,7 +58,7 @@ jobs:
           sudo apt-get install -y -V libarrow-dev
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build fluss-test-cluster binary
         run: cargo build -p fluss-test-cluster

--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: bindings/python
         run: |
           uv sync --extra dev --no-install-project
-          maturin develop
+          uv run --no-sync maturin develop --uv
 
       - name: Run tests (parallel)
         working-directory: bindings/python

--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -61,15 +61,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Rust Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: python-test-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            python-test-${{ runner.os }}-${{ matrix.python }}-
+        uses: Swatinem/rust-cache@v2
 
       - name: Build fluss-test-cluster binary
         run: cargo build -p fluss-test-cluster

--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -61,7 +61,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build fluss-test-cluster binary
         run: cargo build -p fluss-test-cluster

--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -70,11 +70,11 @@ jobs:
         working-directory: bindings/python
         run: |
           uv sync --extra dev --no-install-project
-          uv run maturin develop
+          maturin develop
 
       - name: Run tests (parallel)
         working-directory: bindings/python
-        run: uv run pytest test/ -v -n auto
+        run: uv run --no-sync pytest test/ -v -n auto
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full

--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -61,7 +61,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build fluss-test-cluster binary
         run: cargo build -p fluss-test-cluster

--- a/.github/workflows/build_and_test_rust.yml
+++ b/.github/workflows/build_and_test_rust.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build
         run: cargo build --workspace --all-targets --exclude fluss_python --exclude fluss-cpp

--- a/.github/workflows/build_and_test_rust.yml
+++ b/.github/workflows/build_and_test_rust.yml
@@ -59,15 +59,7 @@ jobs:
           fi
 
       - name: Rust Cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: rust-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            rust-${{ runner.os }}-
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --workspace --all-targets --exclude fluss_python --exclude fluss-cpp

--- a/.github/workflows/build_and_test_rust.yml
+++ b/.github/workflows/build_and_test_rust.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Build
         run: cargo build --workspace --all-targets --exclude fluss_python --exclude fluss-cpp


### PR DESCRIPTION
## Summary
closes #484 

Replace actions/cache with Swatinem/rust-cache to prevent cargo cache eviction across CI workflows.  