### PR TITLE
[python] chore: fix python 3.11 bug with async wait_for

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "pytest>=8.3.5",
     "pytest-asyncio>=0.25.3",
     "pytest-xdist>=3.5.0",
+    "pytest-timeout>=2.3.1",
     "filelock>=3.0",
     "ruff>=0.9.10",
     "maturin>=1.8.2",
@@ -95,6 +96,7 @@ known-first-party = ["fluss"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
+timeout = 30
 
 [tool.mypy]
 python_version = "3.9"

--- a/bindings/python/test/test_log_table.py
+++ b/bindings/python/test/test_log_table.py
@@ -765,8 +765,7 @@ async def test_async_iterator(connection, admin):
             if len(collected) == 5:
                 break
                 
-    # We must race the consumption against a timeout so the test doesn't hang if the iterator is broken
-    await asyncio.wait_for(consume_scanner(), timeout=10.0)
+    await consume_scanner()
     
     assert len(collected) == 5, f"Expected 5 records, got {len(collected)}"
     
@@ -824,7 +823,7 @@ async def test_async_iterator_break_no_leak(connection, admin):
             if len(collected_async) >= 3:
                 break
 
-    await asyncio.wait_for(consume_and_break(), timeout=10.0)
+    await consume_and_break()
     assert len(collected_async) == 3, (
         f"Expected 3 records from async for, got {len(collected_async)}"
     )
@@ -904,7 +903,7 @@ async def test_async_iterator_multiple_batches(connection, admin):
             if len(collected) >= num_records:
                 break
 
-    await asyncio.wait_for(consume_all(), timeout=15.0)
+    await consume_all()
     assert len(collected) == num_records, (
         f"Expected {num_records} records, got {len(collected)}"
     )
@@ -963,7 +962,7 @@ async def test_batch_async_iterator(connection, admin):
             if total_rows >= 6:
                 break
 
-    await asyncio.wait_for(consume_batches(), timeout=15.0)
+    await consume_batches()
 
     assert total_rows >= 6, f"Expected >=6 total rows, got {total_rows}"
     assert len(collected_batches) > 0
@@ -1035,7 +1034,7 @@ async def test_batch_async_iterator_break_no_leak(connection, admin):
             first_batch = rb
             break
 
-    await asyncio.wait_for(consume_and_break(), timeout=10.0)
+    await consume_and_break()
     assert first_batch is not None, "Should have received at least 1 batch"
     assert first_batch.batch.num_rows > 0
 
@@ -1096,7 +1095,7 @@ async def test_batch_async_iterator_multiple_batches(connection, admin):
             if len(all_ids) >= num_records:
                 break
 
-    await asyncio.wait_for(consume_all(), timeout=15.0)
+    await consume_all()
     assert len(all_ids) >= num_records, (
         f"Expected >={num_records} IDs, got {len(all_ids)}"
     )


### PR DESCRIPTION
The tests wrapped async iterator consumption in asyncio.wait_for() as a safety net against hangs. But on Python prior to 3.12 fix(https://github.com/python/cpython/issues/96764), wait_for itself has a bug ([cpython#96764](https://github.com/python/cpython/issues/86296)). Combined with future_into_py/Python::attach(), this creates a GIL deadlock. The safety net was causing the very hang it was meant to prevent.

pytest-timeout (30s per test) is the safety net now. It works at the process level, not the asyncio level, so it can't deadlock.  If the async iterator hangs, it's a real bug that deserves a full stack trace from pytest-timeout.

related to https://github.com/apache/fluss-rust/actions/runs/24237394524/job/70768262474?pr=485