### PR TITLE
[ci/cd] fix python tests with more strict scoping

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -96,7 +96,7 @@ known-first-party = ["fluss"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-timeout = 30
+timeout = 120
 
 [tool.mypy]
 python_version = "3.9"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -95,7 +95,7 @@ known-first-party = ["fluss"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "session"
+asyncio_default_fixture_loop_scope = "function"
 timeout = 30
 
 [tool.mypy]

--- a/bindings/python/test/conftest.py
+++ b/bindings/python/test/conftest.py
@@ -124,7 +124,7 @@ def fluss_cluster():
     yield (plaintext_addr, sasl_addr or plaintext_addr)
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture
 async def connection(fluss_cluster):
     plaintext_addr, _sasl_addr = fluss_cluster
     conn = await _connect(plaintext_addr)
@@ -144,6 +144,6 @@ def plaintext_bootstrap_servers(fluss_cluster):
     return plaintext_addr
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture
 async def admin(connection):
     return connection.get_admin()

--- a/bindings/python/test/conftest.py
+++ b/bindings/python/test/conftest.py
@@ -124,12 +124,16 @@ def fluss_cluster():
     yield (plaintext_addr, sasl_addr or plaintext_addr)
 
 
+_cached_connection = None
+
+
 @pytest_asyncio.fixture
 async def connection(fluss_cluster):
-    plaintext_addr, _sasl_addr = fluss_cluster
-    conn = await _connect(plaintext_addr)
-    yield conn
-    conn.close()
+    global _cached_connection
+    if _cached_connection is None:
+        plaintext_addr, _sasl_addr = fluss_cluster
+        _cached_connection = await _connect(plaintext_addr)
+    yield _cached_connection
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
resolves https://github.com/apache/fluss-rust/issues/492

Needs verification(probably a couple of CI/CD runs):

Python CI tests (especially on 3.11) intermittently hang and get killed by the 30s pytest-timeout. The hangs started after the async for loop support was added (#438), which introduced future_into_py-based polling tasks on the shared tokio runtime.

With session-scoped event loops, all tests within a worker share one event loop. Abandoned async generators from earlier tests (e.g., async for ... break) can leave in-flight future_into_py tasks that interact with subsequent tests via the shared event loop. 
                                                                                                                                                                                                                                                     Per-function scope eliminates cross-test interference.                                                                                                                                                                                  