### PR TITLE
[c++] Add c++ support for Array data type

### DIFF
--- a/bindings/cpp/include/fluss.hpp
+++ b/bindings/cpp/include/fluss.hpp
@@ -620,8 +620,8 @@ class ArrayView {
     ArrayView(ArrayView&& other) noexcept;
     ArrayView& operator=(ArrayView&& other) noexcept;
 
-    size_t Size() const;
-    TypeId ElementType() const;
+    size_t Size() const noexcept;
+    TypeId ElementType() const noexcept;
     bool IsNull(size_t element) const;
 
     bool GetBool(size_t element) const;
@@ -664,6 +664,7 @@ class ArrayWriter {
     ArrayWriter& operator=(ArrayWriter&& other) noexcept;
 
     bool Available() const;
+    size_t Size() const noexcept;
 
     void SetNull(size_t idx);
     void SetBool(size_t idx, bool v);

--- a/bindings/cpp/include/fluss.hpp
+++ b/bindings/cpp/include/fluss.hpp
@@ -50,6 +50,8 @@ struct Lookuper;
 struct ScanResultInner;
 struct GenericRowInner;
 struct LookupResultInner;
+struct ArrayWriterInner;
+struct ArrayViewInner;
 }  // namespace ffi
 
 /// Named constants for Fluss API error codes.
@@ -276,6 +278,7 @@ enum class TypeId {
     Decimal = 14,
     Char = 15,
     Binary = 16,
+    Array = 17,
 };
 
 class DataType {
@@ -305,15 +308,29 @@ class DataType {
     }
     static DataType Char(int32_t length) { return DataType(TypeId::Char, length, 0); }
     static DataType Binary(int32_t length) { return DataType(TypeId::Binary, length, 0); }
+    /// Constructs an `ARRAY<element>` type. The element DataType (possibly
+    /// itself an array) is deep-copied into a shared owning handle so that
+    /// copies of the outer DataType remain cheap while the element lives
+    /// as long as any reference exists.
+    static DataType Array(DataType element) {
+        DataType dt(TypeId::Array, 0, 0);
+        dt.element_type_ = std::make_shared<DataType>(std::move(element));
+        return dt;
+    }
 
     TypeId id() const { return id_; }
     int32_t precision() const { return precision_; }
     int32_t scale() const { return scale_; }
+    /// Returns the element type of an ARRAY. Returns `nullptr` for non-array
+    /// types. The returned pointer is valid as long as this DataType (or a
+    /// copy holding the same shared element) is alive.
+    const DataType* element_type() const { return element_type_.get(); }
 
    private:
     TypeId id_;
     int32_t precision_{0};
     int32_t scale_{0};
+    std::shared_ptr<DataType> element_type_;
 };
 
 constexpr int64_t EARLIEST_OFFSET = -2;
@@ -493,6 +510,12 @@ inline size_t ResolveColumn(const ColumnMap& map, const std::string& name) {
     return it->second.index;
 }
 
+// Forward declaration so NamedGetters can declare GetArrayView(...) even
+// though the concrete class is defined further down.
+}  // namespace detail
+class ArrayView;
+namespace detail {
+
 /// CRTP mixin that adds name-based getters to any class with index-based getters.
 /// Derived must provide: `size_t Resolve(const std::string&) const`
 /// and all the index-based getters (IsNull(idx), GetBool(idx), etc.).
@@ -518,6 +541,51 @@ struct NamedGetters {
     std::string GetDecimalString(const std::string& n) const {
         return Self().GetDecimalString(Self().Resolve(n));
     }
+    size_t GetArraySize(const std::string& n) const {
+        return Self().GetArraySize(Self().Resolve(n));
+    }
+    TypeId GetArrayElementType(const std::string& n) const {
+        return Self().GetArrayElementType(Self().Resolve(n));
+    }
+    bool IsArrayElementNull(const std::string& n, size_t element) const {
+        return Self().IsArrayElementNull(Self().Resolve(n), element);
+    }
+    bool GetArrayBool(const std::string& n, size_t element) const {
+        return Self().GetArrayBool(Self().Resolve(n), element);
+    }
+    int32_t GetArrayInt32(const std::string& n, size_t element) const {
+        return Self().GetArrayInt32(Self().Resolve(n), element);
+    }
+    int64_t GetArrayInt64(const std::string& n, size_t element) const {
+        return Self().GetArrayInt64(Self().Resolve(n), element);
+    }
+    float GetArrayFloat32(const std::string& n, size_t element) const {
+        return Self().GetArrayFloat32(Self().Resolve(n), element);
+    }
+    double GetArrayFloat64(const std::string& n, size_t element) const {
+        return Self().GetArrayFloat64(Self().Resolve(n), element);
+    }
+    std::string GetArrayString(const std::string& n, size_t element) const {
+        return Self().GetArrayString(Self().Resolve(n), element);
+    }
+    std::vector<uint8_t> GetArrayBytes(const std::string& n, size_t element) const {
+        return Self().GetArrayBytes(Self().Resolve(n), element);
+    }
+    fluss::Date GetArrayDate(const std::string& n, size_t element) const {
+        return Self().GetArrayDate(Self().Resolve(n), element);
+    }
+    fluss::Time GetArrayTime(const std::string& n, size_t element) const {
+        return Self().GetArrayTime(Self().Resolve(n), element);
+    }
+    fluss::Timestamp GetArrayTimestamp(const std::string& n, size_t element) const {
+        return Self().GetArrayTimestamp(Self().Resolve(n), element);
+    }
+    std::string GetArrayDecimalString(const std::string& n, size_t element) const {
+        return Self().GetArrayDecimalString(Self().Resolve(n), element);
+    }
+    // Definition appears below the ArrayView class; return-by-value requires
+    // the complete type so we cannot inline the body here.
+    ArrayView GetArrayView(const std::string& n) const;
 
    private:
     const Derived& Self() const { return static_cast<const Derived&>(*this); }
@@ -534,6 +602,90 @@ struct ScanData {
     ScanData& operator=(const ScanData&) = delete;
 };
 }  // namespace detail
+
+/**
+ * @brief Read-only view over a FlussArray column value.
+ *
+ * Obtained from RowView::GetArrayView() / LookupResult::GetArrayView(), and
+ * recursively from ArrayView::GetArray() for nested `ARRAY<ARRAY<...>>`
+ * columns. Owns an opaque Rust handle (FlussArray + element DataType) that
+ * is released on destruction. Move-only.
+ */
+class ArrayView {
+   public:
+    ~ArrayView() noexcept;
+
+    ArrayView(const ArrayView&) = delete;
+    ArrayView& operator=(const ArrayView&) = delete;
+    ArrayView(ArrayView&& other) noexcept;
+    ArrayView& operator=(ArrayView&& other) noexcept;
+
+    size_t Size() const;
+    TypeId ElementType() const;
+    bool IsNull(size_t element) const;
+
+    bool GetBool(size_t element) const;
+    int32_t GetInt32(size_t element) const;
+    int64_t GetInt64(size_t element) const;
+    float GetFloat32(size_t element) const;
+    double GetFloat64(size_t element) const;
+    std::string GetString(size_t element) const;
+    std::vector<uint8_t> GetBytes(size_t element) const;
+    fluss::Date GetDate(size_t element) const;
+    fluss::Time GetTime(size_t element) const;
+    fluss::Timestamp GetTimestampNtz(size_t element) const;
+    fluss::Timestamp GetTimestampLtz(size_t element) const;
+    std::string GetDecimalString(size_t element) const;
+    ArrayView GetArray(size_t element) const;
+
+   private:
+    friend class RowView;
+    friend class LookupResult;
+    explicit ArrayView(ffi::ArrayViewInner* inner) : inner_(inner) {}
+    void Destroy() noexcept;
+    ffi::ArrayViewInner* inner_{nullptr};
+};
+
+namespace detail {
+template <typename Derived>
+inline ArrayView NamedGetters<Derived>::GetArrayView(const std::string& n) const {
+    return Self().GetArrayView(Self().Resolve(n));
+}
+}  // namespace detail
+
+class ArrayWriter {
+   public:
+    ArrayWriter(size_t size, DataType element_type);
+    ~ArrayWriter() noexcept;
+
+    ArrayWriter(const ArrayWriter&) = delete;
+    ArrayWriter& operator=(const ArrayWriter&) = delete;
+    ArrayWriter(ArrayWriter&& other) noexcept;
+    ArrayWriter& operator=(ArrayWriter&& other) noexcept;
+
+    bool Available() const;
+
+    void SetNull(size_t idx);
+    void SetBool(size_t idx, bool v);
+    void SetInt32(size_t idx, int32_t v);
+    void SetInt64(size_t idx, int64_t v);
+    void SetFloat32(size_t idx, float v);
+    void SetFloat64(size_t idx, double v);
+    void SetString(size_t idx, const std::string& v);
+    void SetBytes(size_t idx, const std::vector<uint8_t>& v);
+    void SetDate(size_t idx, fluss::Date d);
+    void SetTime(size_t idx, fluss::Time t);
+    void SetTimestampNtz(size_t idx, fluss::Timestamp ts);
+    void SetTimestampLtz(size_t idx, fluss::Timestamp ts);
+    void SetDecimal(size_t idx, const std::string& value);
+    void SetArray(size_t idx, ArrayWriter&& nested);
+
+   private:
+    friend class GenericRow;
+    void Destroy() noexcept;
+    ffi::ArrayWriterInner* inner_{nullptr};
+    DataType element_type_;
+};
 
 class GenericRow {
    public:
@@ -563,6 +715,7 @@ class GenericRow {
     void SetTimestampNtz(size_t idx, fluss::Timestamp ts);
     void SetTimestampLtz(size_t idx, fluss::Timestamp ts);
     void SetDecimal(size_t idx, const std::string& value);
+    void SetArray(size_t idx, ArrayWriter&& writer);
 
     // ── Name-based setters (require schema — see Table::NewRow()) ───
     void Set(const std::string& name, std::nullptr_t) { SetNull(Resolve(name)); }
@@ -610,6 +763,7 @@ class GenericRow {
                                      "' is not a timestamp column");
         }
     }
+    void Set(const std::string& name, ArrayWriter&& writer) { SetArray(Resolve(name), std::move(writer)); }
 
    private:
     friend class Table;
@@ -669,6 +823,26 @@ class RowView : public detail::NamedGetters<RowView> {
     bool IsDecimal(size_t idx) const;
     std::string GetDecimalString(size_t idx) const;
 
+    // ── Array getters ────────────────────────────────────────────────
+    size_t GetArraySize(size_t idx) const;
+    TypeId GetArrayElementType(size_t idx) const;
+    bool IsArrayElementNull(size_t idx, size_t element) const;
+    bool GetArrayBool(size_t idx, size_t element) const;
+    int32_t GetArrayInt32(size_t idx, size_t element) const;
+    int64_t GetArrayInt64(size_t idx, size_t element) const;
+    float GetArrayFloat32(size_t idx, size_t element) const;
+    double GetArrayFloat64(size_t idx, size_t element) const;
+    std::string GetArrayString(size_t idx, size_t element) const;
+    std::vector<uint8_t> GetArrayBytes(size_t idx, size_t element) const;
+    fluss::Date GetArrayDate(size_t idx, size_t element) const;
+    fluss::Time GetArrayTime(size_t idx, size_t element) const;
+    fluss::Timestamp GetArrayTimestamp(size_t idx, size_t element) const;
+    std::string GetArrayDecimalString(size_t idx, size_t element) const;
+    /// Returns an owning ArrayView over the array column at `idx`. ArrayView
+    /// supports nested arrays via ArrayView::GetArray(). Parity with Python's
+    /// recursive list return from `row.get_array(i)`.
+    ArrayView GetArrayView(size_t idx) const;
+
     // Name-based getters inherited from detail::NamedGetters<RowView>
     using detail::NamedGetters<RowView>::IsNull;
     using detail::NamedGetters<RowView>::GetBool;
@@ -682,6 +856,21 @@ class RowView : public detail::NamedGetters<RowView> {
     using detail::NamedGetters<RowView>::GetTime;
     using detail::NamedGetters<RowView>::GetTimestamp;
     using detail::NamedGetters<RowView>::GetDecimalString;
+    using detail::NamedGetters<RowView>::GetArraySize;
+    using detail::NamedGetters<RowView>::GetArrayElementType;
+    using detail::NamedGetters<RowView>::IsArrayElementNull;
+    using detail::NamedGetters<RowView>::GetArrayBool;
+    using detail::NamedGetters<RowView>::GetArrayInt32;
+    using detail::NamedGetters<RowView>::GetArrayInt64;
+    using detail::NamedGetters<RowView>::GetArrayFloat32;
+    using detail::NamedGetters<RowView>::GetArrayFloat64;
+    using detail::NamedGetters<RowView>::GetArrayString;
+    using detail::NamedGetters<RowView>::GetArrayBytes;
+    using detail::NamedGetters<RowView>::GetArrayDate;
+    using detail::NamedGetters<RowView>::GetArrayTime;
+    using detail::NamedGetters<RowView>::GetArrayTimestamp;
+    using detail::NamedGetters<RowView>::GetArrayDecimalString;
+    using detail::NamedGetters<RowView>::GetArrayView;
 
    private:
     size_t Resolve(const std::string& name) const {
@@ -951,6 +1140,24 @@ class LookupResult : public detail::NamedGetters<LookupResult> {
     bool IsDecimal(size_t idx) const;
     std::string GetDecimalString(size_t idx) const;
 
+    // ── Array getters ────────────────────────────────────────────────
+    size_t GetArraySize(size_t idx) const;
+    TypeId GetArrayElementType(size_t idx) const;
+    bool IsArrayElementNull(size_t idx, size_t element) const;
+    bool GetArrayBool(size_t idx, size_t element) const;
+    int32_t GetArrayInt32(size_t idx, size_t element) const;
+    int64_t GetArrayInt64(size_t idx, size_t element) const;
+    float GetArrayFloat32(size_t idx, size_t element) const;
+    double GetArrayFloat64(size_t idx, size_t element) const;
+    std::string GetArrayString(size_t idx, size_t element) const;
+    std::vector<uint8_t> GetArrayBytes(size_t idx, size_t element) const;
+    fluss::Date GetArrayDate(size_t idx, size_t element) const;
+    fluss::Time GetArrayTime(size_t idx, size_t element) const;
+    fluss::Timestamp GetArrayTimestamp(size_t idx, size_t element) const;
+    std::string GetArrayDecimalString(size_t idx, size_t element) const;
+    /// See RowView::GetArrayView for semantics. Supports nested arrays.
+    ArrayView GetArrayView(size_t idx) const;
+
     // Name-based getters inherited from detail::NamedGetters<LookupResult>
     using detail::NamedGetters<LookupResult>::IsNull;
     using detail::NamedGetters<LookupResult>::GetBool;
@@ -964,6 +1171,21 @@ class LookupResult : public detail::NamedGetters<LookupResult> {
     using detail::NamedGetters<LookupResult>::GetTime;
     using detail::NamedGetters<LookupResult>::GetTimestamp;
     using detail::NamedGetters<LookupResult>::GetDecimalString;
+    using detail::NamedGetters<LookupResult>::GetArraySize;
+    using detail::NamedGetters<LookupResult>::GetArrayElementType;
+    using detail::NamedGetters<LookupResult>::IsArrayElementNull;
+    using detail::NamedGetters<LookupResult>::GetArrayBool;
+    using detail::NamedGetters<LookupResult>::GetArrayInt32;
+    using detail::NamedGetters<LookupResult>::GetArrayInt64;
+    using detail::NamedGetters<LookupResult>::GetArrayFloat32;
+    using detail::NamedGetters<LookupResult>::GetArrayFloat64;
+    using detail::NamedGetters<LookupResult>::GetArrayString;
+    using detail::NamedGetters<LookupResult>::GetArrayBytes;
+    using detail::NamedGetters<LookupResult>::GetArrayDate;
+    using detail::NamedGetters<LookupResult>::GetArrayTime;
+    using detail::NamedGetters<LookupResult>::GetArrayTimestamp;
+    using detail::NamedGetters<LookupResult>::GetArrayDecimalString;
+    using detail::NamedGetters<LookupResult>::GetArrayView;
 
    private:
     friend class Lookuper;

--- a/bindings/cpp/src/admin.cpp
+++ b/bindings/cpp/src/admin.cpp
@@ -21,6 +21,7 @@
 #include "fluss.hpp"
 #include "lib.rs.h"
 #include "rust/cxx.h"
+#include <exception>
 
 namespace fluss {
 
@@ -83,7 +84,11 @@ Result Admin::GetTableInfo(const TablePath& table_path, TableInfo& out) {
 
     auto result = utils::from_ffi_result(ffi_result.result);
     if (result.Ok()) {
-        out = utils::from_ffi_table_info(ffi_result.table_info);
+        try {
+            out = utils::from_ffi_table_info(ffi_result.table_info);
+        } catch (const std::exception& e) {
+            return utils::make_client_error(std::string("Failed to parse table metadata: ") + e.what());
+        }
     }
 
     return result;

--- a/bindings/cpp/src/ffi_converter.hpp
+++ b/bindings/cpp/src/ffi_converter.hpp
@@ -27,6 +27,64 @@
 namespace fluss {
 namespace utils {
 
+/// Compact FFI representation of a (possibly nested) array type.
+///
+/// `nesting` counts the number of ARRAY wrappers stripped to reach the leaf
+/// element type. `leaf_type`/`leaf_precision`/`leaf_scale` describe that leaf
+/// scalar. A non-array input produces a zero-initialised value (nesting == 0).
+///
+/// Using a flat representation — rather than serialising a recursive
+/// `DataType` — keeps the cxx bridge contract small (four `i32`s inside
+/// `FfiColumn`) while preserving full schema fidelity across the FFI boundary
+/// when paired with rebuild_array_type().
+struct FlattenedArrayType {
+    int32_t nesting{0};
+    int32_t leaf_type{0};
+    int32_t leaf_precision{0};
+    int32_t leaf_scale{0};
+};
+
+/// Flattens an `ARRAY<ARRAY<...<leaf>>>` DataType into a FlattenedArrayType.
+///
+/// Contract:
+///   - If `data_type` is not an ARRAY, returns a zero-valued FlattenedArrayType
+///     and callers must use the column's own `id/precision/scale` instead.
+///   - If `data_type` is an ARRAY but has a null element_type() chain (which
+///     should only happen on malformed input), returns a zero-valued result to
+///     signal the caller to reject the schema.
+///   - Otherwise, `nesting >= 1` and leaf_* describe the innermost scalar.
+inline FlattenedArrayType flatten_array_type(const DataType& data_type) {
+    FlattenedArrayType out;
+    if (data_type.id() != TypeId::Array) {
+        return out;
+    }
+
+    const DataType* current = &data_type;
+    while (current && current->id() == TypeId::Array) {
+        out.nesting += 1;
+        current = current->element_type();
+    }
+    if (!current) {
+        return FlattenedArrayType{};
+    }
+
+    out.leaf_type = static_cast<int32_t>(current->id());
+    out.leaf_precision = current->precision();
+    out.leaf_scale = current->scale();
+    return out;
+}
+
+/// Inverse of flatten_array_type: rebuilds an `ARRAY<ARRAY<...<leaf>>>` type
+/// from the compact flat form. Requires `flat.nesting >= 1`; callers handle
+/// the `nesting == 0` case by using a plain scalar DataType directly.
+inline DataType rebuild_array_type(const FlattenedArrayType& flat) {
+    DataType dt(static_cast<TypeId>(flat.leaf_type), flat.leaf_precision, flat.leaf_scale);
+    for (int32_t i = 0; i < flat.nesting; ++i) {
+        dt = DataType::Array(std::move(dt));
+    }
+    return dt;
+}
+
 inline Result make_error(int32_t code, std::string msg) { return Result{code, std::move(msg)}; }
 
 inline Result make_client_error(std::string msg) {
@@ -94,6 +152,17 @@ inline ffi::FfiColumn to_ffi_column(const Column& col) {
     ffi_col.comment = rust::String(col.comment);
     ffi_col.precision = col.data_type.precision();
     ffi_col.scale = col.data_type.scale();
+    auto flat = flatten_array_type(col.data_type);
+    ffi_col.array_nesting = flat.nesting;
+    if (flat.nesting > 0 && flat.leaf_type != 0) {
+        ffi_col.element_data_type = flat.leaf_type;
+        ffi_col.element_precision = flat.leaf_precision;
+        ffi_col.element_scale = flat.leaf_scale;
+    } else {
+        ffi_col.element_data_type = 0;
+        ffi_col.element_precision = 0;
+        ffi_col.element_scale = 0;
+    }
     return ffi_col;
 }
 
@@ -158,10 +227,18 @@ inline ffi::FfiTableDescriptor to_ffi_table_descriptor(const TableDescriptor& de
 }
 
 inline Column from_ffi_column(const ffi::FfiColumn& ffi_col) {
-    return Column{
-        std::string(ffi_col.name),
-        DataType(static_cast<TypeId>(ffi_col.data_type), ffi_col.precision, ffi_col.scale),
-        std::string(ffi_col.comment)};
+    auto type_id = static_cast<TypeId>(ffi_col.data_type);
+    DataType dt(type_id, ffi_col.precision, ffi_col.scale);
+    if (type_id == TypeId::Array && ffi_col.element_data_type != 0) {
+        int32_t nesting = ffi_col.array_nesting > 0 ? ffi_col.array_nesting : 1;
+        dt = rebuild_array_type(FlattenedArrayType{
+            nesting,
+            ffi_col.element_data_type,
+            ffi_col.element_precision,
+            ffi_col.element_scale,
+        });
+    }
+    return Column{std::string(ffi_col.name), std::move(dt), std::string(ffi_col.comment)};
 }
 
 inline Schema from_ffi_schema(const ffi::FfiSchema& ffi_schema) {

--- a/bindings/cpp/src/ffi_converter.hpp
+++ b/bindings/cpp/src/ffi_converter.hpp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <cassert>
+#include <stdexcept>
 
 #include "fluss.hpp"
 #include "lib.rs.h"
@@ -229,7 +230,48 @@ inline ffi::FfiTableDescriptor to_ffi_table_descriptor(const TableDescriptor& de
 inline Column from_ffi_column(const ffi::FfiColumn& ffi_col) {
     auto type_id = static_cast<TypeId>(ffi_col.data_type);
     DataType dt(type_id, ffi_col.precision, ffi_col.scale);
-    if (type_id == TypeId::Array && ffi_col.element_data_type != 0) {
+    if (type_id == TypeId::Array) {
+        if (ffi_col.element_data_type == 0) {
+            throw std::runtime_error("Malformed ARRAY column '" + std::string(ffi_col.name) +
+                                     "': missing element_data_type");
+        }
+        if (ffi_col.array_nesting < 0) {
+            throw std::runtime_error("Malformed ARRAY column '" + std::string(ffi_col.name) +
+                                     "': array_nesting must be non-negative");
+        }
+        if (ffi_col.element_data_type == static_cast<int32_t>(TypeId::Array)) {
+            throw std::runtime_error("Malformed ARRAY column '" + std::string(ffi_col.name) +
+                                     "': leaf element_data_type cannot be ARRAY");
+        }
+        auto is_supported_leaf_type = [](int32_t leaf_type) {
+            switch (static_cast<TypeId>(leaf_type)) {
+                case TypeId::Boolean:
+                case TypeId::TinyInt:
+                case TypeId::SmallInt:
+                case TypeId::Int:
+                case TypeId::BigInt:
+                case TypeId::Float:
+                case TypeId::Double:
+                case TypeId::String:
+                case TypeId::Bytes:
+                case TypeId::Date:
+                case TypeId::Time:
+                case TypeId::Timestamp:
+                case TypeId::TimestampLtz:
+                case TypeId::Decimal:
+                case TypeId::Char:
+                case TypeId::Binary:
+                    return true;
+                default:
+                    return false;
+            }
+        };
+        if (!is_supported_leaf_type(ffi_col.element_data_type)) {
+            throw std::runtime_error("Malformed ARRAY column '" + std::string(ffi_col.name) +
+                                     "': unsupported leaf element_data_type " +
+                                     std::to_string(ffi_col.element_data_type));
+        }
+
         int32_t nesting = ffi_col.array_nesting > 0 ? ffi_col.array_nesting : 1;
         dt = rebuild_array_type(FlattenedArrayType{
             nesting,

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -2093,11 +2093,9 @@ impl GenericRowInner {
     fn gr_set_array(&mut self, idx: usize, writer: &mut ArrayWriterInner) -> Result<(), String> {
         self.ensure_size(idx);
         writer.complete_if_needed()?;
-        // After `complete_if_needed()?` succeeds, `completed` is guaranteed `Some`.
-        let arr = writer
-            .completed
-            .take()
-            .expect("ArrayWriterInner::completed should be populated after complete_if_needed");
+        let arr = writer.completed.take().ok_or_else(|| {
+            "ArrayWriter invariant violation: completed array missing after finalize".to_string()
+        })?;
         self.row.set_field(idx, fcore::row::Datum::Array(arr));
         Ok(())
     }
@@ -2447,8 +2445,8 @@ mod row_reader {
         field: usize,
         element: usize,
     ) -> Result<bool, String> {
-        let arr = get_fluss_array(row, columns, field)?;
-        array_reader::get_bool(&arr, element)
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_bool(&arr, elem, element)
     }
 
     pub fn get_array_i32(
@@ -2467,8 +2465,8 @@ mod row_reader {
         field: usize,
         element: usize,
     ) -> Result<i64, String> {
-        let arr = get_fluss_array(row, columns, field)?;
-        array_reader::get_i64(&arr, element)
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_i64(&arr, elem, element)
     }
 
     pub fn get_array_f32(
@@ -2477,8 +2475,8 @@ mod row_reader {
         field: usize,
         element: usize,
     ) -> Result<f32, String> {
-        let arr = get_fluss_array(row, columns, field)?;
-        array_reader::get_f32(&arr, element)
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_f32(&arr, elem, element)
     }
 
     pub fn get_array_f64(
@@ -2487,8 +2485,8 @@ mod row_reader {
         field: usize,
         element: usize,
     ) -> Result<f64, String> {
-        let arr = get_fluss_array(row, columns, field)?;
-        array_reader::get_f64(&arr, element)
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_f64(&arr, elem, element)
     }
 
     pub fn get_array_str(
@@ -2497,8 +2495,8 @@ mod row_reader {
         field: usize,
         element: usize,
     ) -> Result<String, String> {
-        let arr = get_fluss_array(row, columns, field)?;
-        array_reader::get_str(&arr, element)
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_str(&arr, elem, element)
     }
 
     pub fn get_array_bytes(
@@ -2507,8 +2505,8 @@ mod row_reader {
         field: usize,
         element: usize,
     ) -> Result<Vec<u8>, String> {
-        let arr = get_fluss_array(row, columns, field)?;
-        array_reader::get_bytes(&arr, element)
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_bytes(&arr, elem, element)
     }
 
     pub fn get_array_date_days(
@@ -2517,8 +2515,8 @@ mod row_reader {
         field: usize,
         element: usize,
     ) -> Result<i32, String> {
-        let arr = get_fluss_array(row, columns, field)?;
-        array_reader::get_date_days(&arr, element)
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_date_days(&arr, elem, element)
     }
 
     pub fn get_array_time_millis(
@@ -2527,8 +2525,8 @@ mod row_reader {
         field: usize,
         element: usize,
     ) -> Result<i32, String> {
-        let arr = get_fluss_array(row, columns, field)?;
-        array_reader::get_time_millis(&arr, element)
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_time_millis(&arr, elem, element)
     }
 
     pub fn get_array_ts_millis(
@@ -2575,8 +2573,8 @@ mod row_reader {
 //
 // Shared by the top-level `row_reader::get_array_*` wrappers and by
 // `ArrayViewInner` (which exposes recursive/nested access to C++). Keeping
-// one implementation here guarantees identical bounds-checking, error
-// messages, and type dispatch across flat and nested reads.
+// one implementation here guarantees identical bounds-checking, null
+// validation, type checking, and type dispatch across flat and nested reads.
 // ============================================================================
 
 mod array_reader {
@@ -2597,6 +2595,48 @@ mod array_reader {
         }
     }
 
+    fn ensure_non_null(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+        op: &str,
+    ) -> Result<(), String> {
+        if arr.is_null_at(element) {
+            Err(format!(
+                "{op}: element at index {element} is null; call array_is_null first"
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn ensure_type(
+        elem_type: &fcore::metadata::DataType,
+        op: &str,
+        expected: &str,
+        allowed: impl FnOnce(&fcore::metadata::DataType) -> bool,
+    ) -> Result<(), String> {
+        if allowed(elem_type) {
+            Ok(())
+        } else {
+            Err(format!(
+                "{op}: element type is {elem_type}, expected {expected}"
+            ))
+        }
+    }
+
+    fn ensure_readable(
+        arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
+        element: usize,
+        op: &str,
+        expected: &str,
+        allowed: impl FnOnce(&fcore::metadata::DataType) -> bool,
+    ) -> Result<(), String> {
+        validate_index(arr, element, op)?;
+        ensure_type(elem_type, op, expected, allowed)?;
+        ensure_non_null(arr, element, op)
+    }
+
     pub fn is_null(
         arr: &fcore::row::binary_array::FlussArray,
         element: usize,
@@ -2607,9 +2647,12 @@ mod array_reader {
 
     pub fn get_bool(
         arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<bool, String> {
-        validate_index(arr, element, "array_bool")?;
+        ensure_readable(arr, elem_type, element, "array_bool", "BOOLEAN", |dt| {
+            matches!(dt, fcore::metadata::DataType::Boolean(_))
+        })?;
         arr.get_boolean(element).map_err(|e| e.to_string())
     }
 
@@ -2618,7 +2661,21 @@ mod array_reader {
         elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<i32, String> {
-        validate_index(arr, element, "array_i32")?;
+        ensure_readable(
+            arr,
+            elem_type,
+            element,
+            "array_i32",
+            "TINYINT/SMALLINT/INT",
+            |dt| {
+                matches!(
+                    dt,
+                    fcore::metadata::DataType::TinyInt(_)
+                        | fcore::metadata::DataType::SmallInt(_)
+                        | fcore::metadata::DataType::Int(_)
+                )
+            },
+        )?;
         match elem_type {
             fcore::metadata::DataType::TinyInt(_) => arr
                 .get_byte(element)
@@ -2628,39 +2685,55 @@ mod array_reader {
                 .get_short(element)
                 .map(|v| v as i32)
                 .map_err(|e| e.to_string()),
-            _ => arr.get_int(element).map_err(|e| e.to_string()),
+            fcore::metadata::DataType::Int(_) => arr.get_int(element).map_err(|e| e.to_string()),
+            _ => unreachable!("type validated by ensure_readable"),
         }
     }
 
     pub fn get_i64(
         arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<i64, String> {
-        validate_index(arr, element, "array_i64")?;
+        ensure_readable(arr, elem_type, element, "array_i64", "BIGINT", |dt| {
+            matches!(dt, fcore::metadata::DataType::BigInt(_))
+        })?;
         arr.get_long(element).map_err(|e| e.to_string())
     }
 
     pub fn get_f32(
         arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<f32, String> {
-        validate_index(arr, element, "array_f32")?;
+        ensure_readable(arr, elem_type, element, "array_f32", "FLOAT", |dt| {
+            matches!(dt, fcore::metadata::DataType::Float(_))
+        })?;
         arr.get_float(element).map_err(|e| e.to_string())
     }
 
     pub fn get_f64(
         arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<f64, String> {
-        validate_index(arr, element, "array_f64")?;
+        ensure_readable(arr, elem_type, element, "array_f64", "DOUBLE", |dt| {
+            matches!(dt, fcore::metadata::DataType::Double(_))
+        })?;
         arr.get_double(element).map_err(|e| e.to_string())
     }
 
     pub fn get_str(
         arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<String, String> {
-        validate_index(arr, element, "array_str")?;
+        ensure_readable(arr, elem_type, element, "array_str", "STRING/CHAR", |dt| {
+            matches!(
+                dt,
+                fcore::metadata::DataType::String(_) | fcore::metadata::DataType::Char(_)
+            )
+        })?;
         arr.get_string(element)
             .map(|s| s.to_string())
             .map_err(|e| e.to_string())
@@ -2668,9 +2741,22 @@ mod array_reader {
 
     pub fn get_bytes(
         arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<Vec<u8>, String> {
-        validate_index(arr, element, "array_bytes")?;
+        ensure_readable(
+            arr,
+            elem_type,
+            element,
+            "array_bytes",
+            "BYTES/BINARY",
+            |dt| {
+                matches!(
+                    dt,
+                    fcore::metadata::DataType::Bytes(_) | fcore::metadata::DataType::Binary(_)
+                )
+            },
+        )?;
         arr.get_binary(element)
             .map(|b| b.to_vec())
             .map_err(|e| e.to_string())
@@ -2678,9 +2764,12 @@ mod array_reader {
 
     pub fn get_date_days(
         arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<i32, String> {
-        validate_index(arr, element, "array_date")?;
+        ensure_readable(arr, elem_type, element, "array_date", "DATE", |dt| {
+            matches!(dt, fcore::metadata::DataType::Date(_))
+        })?;
         arr.get_date(element)
             .map(|d| d.get_inner())
             .map_err(|e| e.to_string())
@@ -2688,9 +2777,12 @@ mod array_reader {
 
     pub fn get_time_millis(
         arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<i32, String> {
-        validate_index(arr, element, "array_time")?;
+        ensure_readable(arr, elem_type, element, "array_time", "TIME", |dt| {
+            matches!(dt, fcore::metadata::DataType::Time(_))
+        })?;
         arr.get_time(element)
             .map(|t| t.get_inner())
             .map_err(|e| e.to_string())
@@ -2701,7 +2793,20 @@ mod array_reader {
         elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<i64, String> {
-        validate_index(arr, element, "array_ts_millis")?;
+        ensure_readable(
+            arr,
+            elem_type,
+            element,
+            "array_ts_millis",
+            "TIMESTAMP/TIMESTAMP_LTZ",
+            |dt| {
+                matches!(
+                    dt,
+                    fcore::metadata::DataType::Timestamp(_)
+                        | fcore::metadata::DataType::TimestampLTz(_)
+                )
+            },
+        )?;
         match elem_type {
             fcore::metadata::DataType::TimestampLTz(ts) => arr
                 .get_timestamp_ltz(element, ts.precision())
@@ -2711,9 +2816,7 @@ mod array_reader {
                 .get_timestamp_ntz(element, ts.precision())
                 .map(|v| v.get_millisecond())
                 .map_err(|e| e.to_string()),
-            dt => Err(format!(
-                "array_ts_millis: element type is {dt}, not timestamp"
-            )),
+            _ => unreachable!("type validated by ensure_readable"),
         }
     }
 
@@ -2722,7 +2825,20 @@ mod array_reader {
         elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<i32, String> {
-        validate_index(arr, element, "array_ts_nanos")?;
+        ensure_readable(
+            arr,
+            elem_type,
+            element,
+            "array_ts_nanos",
+            "TIMESTAMP/TIMESTAMP_LTZ",
+            |dt| {
+                matches!(
+                    dt,
+                    fcore::metadata::DataType::Timestamp(_)
+                        | fcore::metadata::DataType::TimestampLTz(_)
+                )
+            },
+        )?;
         match elem_type {
             fcore::metadata::DataType::TimestampLTz(ts) => arr
                 .get_timestamp_ltz(element, ts.precision())
@@ -2732,9 +2848,7 @@ mod array_reader {
                 .get_timestamp_ntz(element, ts.precision())
                 .map(|v| v.get_nano_of_millisecond())
                 .map_err(|e| e.to_string()),
-            dt => Err(format!(
-                "array_ts_nanos: element type is {dt}, not timestamp"
-            )),
+            _ => unreachable!("type validated by ensure_readable"),
         }
     }
 
@@ -2743,7 +2857,9 @@ mod array_reader {
         elem_type: &fcore::metadata::DataType,
         element: usize,
     ) -> Result<String, String> {
-        validate_index(arr, element, "array_decimal")?;
+        ensure_readable(arr, elem_type, element, "array_decimal", "DECIMAL", |dt| {
+            matches!(dt, fcore::metadata::DataType::Decimal(_))
+        })?;
         match elem_type {
             fcore::metadata::DataType::Decimal(dd) => {
                 let decimal = arr
@@ -2751,7 +2867,7 @@ mod array_reader {
                     .map_err(|e| e.to_string())?;
                 Ok(decimal.to_big_decimal().to_string())
             }
-            dt => Err(format!("array_decimal: element type is {dt}, not decimal")),
+            _ => unreachable!("type validated by ensure_readable"),
         }
     }
 
@@ -2766,13 +2882,15 @@ mod array_reader {
         ),
         String,
     > {
-        validate_index(arr, element, "array_nested")?;
+        ensure_readable(arr, elem_type, element, "array_nested", "ARRAY", |dt| {
+            matches!(dt, fcore::metadata::DataType::Array(_))
+        })?;
         match elem_type {
             fcore::metadata::DataType::Array(at) => {
                 let nested = arr.get_array(element).map_err(|e| e.to_string())?;
                 Ok((nested, at.get_element_type().clone()))
             }
-            dt => Err(format!("array_nested: element type is {dt}, not array")),
+            _ => unreachable!("type validated by ensure_readable"),
         }
     }
 }
@@ -3143,7 +3261,7 @@ impl ArrayViewInner {
     }
 
     fn av_get_bool(&self, element: usize) -> Result<bool, String> {
-        array_reader::get_bool(&self.array, element)
+        array_reader::get_bool(&self.array, &self.element_type, element)
     }
 
     fn av_get_i32(&self, element: usize) -> Result<i32, String> {
@@ -3151,31 +3269,31 @@ impl ArrayViewInner {
     }
 
     fn av_get_i64(&self, element: usize) -> Result<i64, String> {
-        array_reader::get_i64(&self.array, element)
+        array_reader::get_i64(&self.array, &self.element_type, element)
     }
 
     fn av_get_f32(&self, element: usize) -> Result<f32, String> {
-        array_reader::get_f32(&self.array, element)
+        array_reader::get_f32(&self.array, &self.element_type, element)
     }
 
     fn av_get_f64(&self, element: usize) -> Result<f64, String> {
-        array_reader::get_f64(&self.array, element)
+        array_reader::get_f64(&self.array, &self.element_type, element)
     }
 
     fn av_get_str(&self, element: usize) -> Result<String, String> {
-        array_reader::get_str(&self.array, element)
+        array_reader::get_str(&self.array, &self.element_type, element)
     }
 
     fn av_get_bytes(&self, element: usize) -> Result<Vec<u8>, String> {
-        array_reader::get_bytes(&self.array, element)
+        array_reader::get_bytes(&self.array, &self.element_type, element)
     }
 
     fn av_get_date_days(&self, element: usize) -> Result<i32, String> {
-        array_reader::get_date_days(&self.array, element)
+        array_reader::get_date_days(&self.array, &self.element_type, element)
     }
 
     fn av_get_time_millis(&self, element: usize) -> Result<i32, String> {
-        array_reader::get_time_millis(&self.array, element)
+        array_reader::get_time_millis(&self.array, &self.element_type, element)
     }
 
     fn av_get_ts_millis(&self, element: usize) -> Result<i64, String> {
@@ -3475,11 +3593,10 @@ impl ArrayWriterInner {
             ));
         }
         nested.complete_if_needed()?;
-        // After `complete_if_needed()?` succeeds, `completed` is guaranteed `Some`.
-        let arr = nested
-            .completed
-            .as_ref()
-            .expect("ArrayWriterInner::completed should be populated after complete_if_needed");
+        let arr = nested.completed.as_ref().ok_or_else(|| {
+            "ArrayWriter invariant violation: nested completed array missing after finalize"
+                .to_string()
+        })?;
         self.writer_mut()?.write_array(idx, arr);
         Ok(())
     }

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -17,6 +17,7 @@
 
 mod types;
 
+use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
@@ -85,6 +86,10 @@ mod ffi {
         comment: String,
         precision: i32,
         scale: i32,
+        array_nesting: i32,
+        element_data_type: i32,
+        element_precision: i32,
+        element_scale: i32,
     }
 
     struct FfiSchema {
@@ -279,6 +284,8 @@ mod ffi {
         type ScanResultInner;
         type GenericRowInner;
         type LookupResultInner;
+        type ArrayWriterInner;
+        type ArrayViewInner;
 
         // Connection
         fn new_connection(config: &FfiConfig) -> FfiPtrResult;
@@ -383,6 +390,48 @@ mod ffi {
         fn gr_set_ts_ntz(self: &mut GenericRowInner, idx: usize, millis: i64, nanos: i32);
         fn gr_set_ts_ltz(self: &mut GenericRowInner, idx: usize, millis: i64, nanos: i32);
         fn gr_set_decimal_str(self: &mut GenericRowInner, idx: usize, val: &str);
+        fn gr_set_array(
+            self: &mut GenericRowInner,
+            idx: usize,
+            writer: &mut ArrayWriterInner,
+        ) -> Result<()>;
+
+        // ArrayWriterInner — opaque array builder for writes
+        fn new_array_writer(
+            size: usize,
+            element_leaf_type_id: i32,
+            precision: u32,
+            scale: u32,
+            array_nesting: u32,
+        ) -> Result<Box<ArrayWriterInner>>;
+        fn aw_set_null(self: &mut ArrayWriterInner, idx: usize) -> Result<()>;
+        fn aw_set_bool(self: &mut ArrayWriterInner, idx: usize, val: bool) -> Result<()>;
+        fn aw_set_i32(self: &mut ArrayWriterInner, idx: usize, val: i32) -> Result<()>;
+        fn aw_set_i64(self: &mut ArrayWriterInner, idx: usize, val: i64) -> Result<()>;
+        fn aw_set_f32(self: &mut ArrayWriterInner, idx: usize, val: f32) -> Result<()>;
+        fn aw_set_f64(self: &mut ArrayWriterInner, idx: usize, val: f64) -> Result<()>;
+        fn aw_set_str(self: &mut ArrayWriterInner, idx: usize, val: &str) -> Result<()>;
+        fn aw_set_bytes(self: &mut ArrayWriterInner, idx: usize, val: &[u8]) -> Result<()>;
+        fn aw_set_date(self: &mut ArrayWriterInner, idx: usize, days: i32) -> Result<()>;
+        fn aw_set_time(self: &mut ArrayWriterInner, idx: usize, millis: i32) -> Result<()>;
+        fn aw_set_ts_ntz(
+            self: &mut ArrayWriterInner,
+            idx: usize,
+            millis: i64,
+            nanos: i32,
+        ) -> Result<()>;
+        fn aw_set_ts_ltz(
+            self: &mut ArrayWriterInner,
+            idx: usize,
+            millis: i64,
+            nanos: i32,
+        ) -> Result<()>;
+        fn aw_set_decimal_str(self: &mut ArrayWriterInner, idx: usize, val: &str) -> Result<()>;
+        fn aw_set_array(
+            self: &mut ArrayWriterInner,
+            idx: usize,
+            nested: &mut ArrayWriterInner,
+        ) -> Result<()>;
 
         // AppendWriter
         unsafe fn delete_append_writer(writer: *mut AppendWriter);
@@ -430,6 +479,78 @@ mod ffi {
         fn lv_get_ts_nanos(self: &LookupResultInner, field: usize) -> Result<i32>;
         fn lv_is_ts_ltz(self: &LookupResultInner, field: usize) -> Result<bool>;
         fn lv_get_decimal_str(self: &LookupResultInner, field: usize) -> Result<String>;
+
+        fn lv_get_array_size(self: &LookupResultInner, field: usize) -> Result<usize>;
+        fn lv_get_array_is_null(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<bool>;
+        fn lv_get_array_bool(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<bool>;
+        fn lv_get_array_i32(self: &LookupResultInner, field: usize, element: usize) -> Result<i32>;
+        fn lv_get_array_i64(self: &LookupResultInner, field: usize, element: usize) -> Result<i64>;
+        fn lv_get_array_f32(self: &LookupResultInner, field: usize, element: usize) -> Result<f32>;
+        fn lv_get_array_f64(self: &LookupResultInner, field: usize, element: usize) -> Result<f64>;
+        fn lv_get_array_str(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<String>;
+        fn lv_get_array_bytes(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<Vec<u8>>;
+        fn lv_get_array_date_days(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<i32>;
+        fn lv_get_array_time_millis(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<i32>;
+        fn lv_get_array_ts_millis(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<i64>;
+        fn lv_get_array_ts_nanos(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<i32>;
+        fn lv_get_array_decimal_str(
+            self: &LookupResultInner,
+            field: usize,
+            element: usize,
+        ) -> Result<String>;
+        fn lv_get_array_element_type(self: &LookupResultInner, field: usize) -> Result<i32>;
+        fn lv_get_array_view(self: &LookupResultInner, field: usize)
+        -> Result<Box<ArrayViewInner>>;
+
+        // ArrayViewInner — opaque recursive array reader for C++ bindings
+        fn av_size(self: &ArrayViewInner) -> usize;
+        fn av_element_type_id(self: &ArrayViewInner) -> i32;
+        fn av_is_null(self: &ArrayViewInner, element: usize) -> Result<bool>;
+        fn av_get_bool(self: &ArrayViewInner, element: usize) -> Result<bool>;
+        fn av_get_i32(self: &ArrayViewInner, element: usize) -> Result<i32>;
+        fn av_get_i64(self: &ArrayViewInner, element: usize) -> Result<i64>;
+        fn av_get_f32(self: &ArrayViewInner, element: usize) -> Result<f32>;
+        fn av_get_f64(self: &ArrayViewInner, element: usize) -> Result<f64>;
+        fn av_get_str(self: &ArrayViewInner, element: usize) -> Result<String>;
+        fn av_get_bytes(self: &ArrayViewInner, element: usize) -> Result<Vec<u8>>;
+        fn av_get_date_days(self: &ArrayViewInner, element: usize) -> Result<i32>;
+        fn av_get_time_millis(self: &ArrayViewInner, element: usize) -> Result<i32>;
+        fn av_get_ts_millis(self: &ArrayViewInner, element: usize) -> Result<i64>;
+        fn av_get_ts_nanos(self: &ArrayViewInner, element: usize) -> Result<i32>;
+        fn av_get_decimal_str(self: &ArrayViewInner, element: usize) -> Result<String>;
+        fn av_get_nested(self: &ArrayViewInner, element: usize) -> Result<Box<ArrayViewInner>>;
 
         // LogScanner
         unsafe fn delete_log_scanner(scanner: *mut LogScanner);
@@ -551,6 +672,111 @@ mod ffi {
             rec: usize,
             field: usize,
         ) -> Result<String>;
+
+        fn sv_get_array_size(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+        ) -> Result<usize>;
+        fn sv_get_array_is_null(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<bool>;
+        fn sv_get_array_bool(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<bool>;
+        fn sv_get_array_i32(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<i32>;
+        fn sv_get_array_i64(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<i64>;
+        fn sv_get_array_f32(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<f32>;
+        fn sv_get_array_f64(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<f64>;
+        fn sv_get_array_str(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<String>;
+        fn sv_get_array_bytes(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<Vec<u8>>;
+        fn sv_get_array_date_days(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<i32>;
+        fn sv_get_array_time_millis(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<i32>;
+        fn sv_get_array_ts_millis(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<i64>;
+        fn sv_get_array_ts_nanos(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<i32>;
+        fn sv_get_array_decimal_str(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+            element: usize,
+        ) -> Result<String>;
+        fn sv_get_array_element_type(self: &ScanResultInner, field: usize) -> Result<i32>;
+        fn sv_get_array_view(
+            self: &ScanResultInner,
+            bucket: usize,
+            rec: usize,
+            field: usize,
+        ) -> Result<Box<ArrayViewInner>>;
 
         fn sv_bucket_infos(self: &ScanResultInner) -> &Vec<FfiBucketInfo>;
     }
@@ -1864,6 +2090,18 @@ impl GenericRowInner {
         );
     }
 
+    fn gr_set_array(&mut self, idx: usize, writer: &mut ArrayWriterInner) -> Result<(), String> {
+        self.ensure_size(idx);
+        writer.complete_if_needed()?;
+        // After `complete_if_needed()?` succeeds, `completed` is guaranteed `Some`.
+        let arr = writer
+            .completed
+            .take()
+            .expect("ArrayWriterInner::completed should be populated after complete_if_needed");
+        self.row.set_field(idx, fcore::row::Datum::Array(arr));
+        Ok(())
+    }
+
     fn ensure_size(&mut self, idx: usize) {
         if self.row.values.len() <= idx {
             self.row.values.resize(idx + 1, fcore::row::Datum::Null);
@@ -1876,6 +2114,7 @@ impl GenericRowInner {
 // ============================================================================
 
 mod row_reader {
+    use super::array_reader;
     use fcore::row::InternalRow;
     use fluss as fcore;
 
@@ -2144,6 +2383,435 @@ mod row_reader {
             dt => Err(format!("get_decimal_str: unexpected type {dt}")),
         }
     }
+
+    fn get_fluss_array(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+    ) -> Result<fcore::row::binary_array::FlussArray, String> {
+        validate(row, columns, field, "get_array", |dt| {
+            matches!(dt, fcore::metadata::DataType::Array(_))
+        })?;
+        row.get_array(field).map_err(|e| e.to_string())
+    }
+
+    pub fn get_array_element_type(
+        columns: &[fcore::metadata::Column],
+        field: usize,
+    ) -> Result<&fcore::metadata::DataType, String> {
+        let col = get_column(columns, field)?;
+        match col.data_type() {
+            fcore::metadata::DataType::Array(at) => Ok(at.get_element_type()),
+            dt => Err(format!("get_array: column {field} is not Array, got {dt}")),
+        }
+    }
+
+    pub fn get_array_size(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+    ) -> Result<usize, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        Ok(arr.size())
+    }
+
+    pub fn get_array_and_elem_type<'a>(
+        row: &dyn InternalRow,
+        columns: &'a [fcore::metadata::Column],
+        field: usize,
+    ) -> Result<
+        (
+            fcore::row::binary_array::FlussArray,
+            &'a fcore::metadata::DataType,
+        ),
+        String,
+    > {
+        let arr = get_fluss_array(row, columns, field)?;
+        let elem = get_array_element_type(columns, field)?;
+        Ok((arr, elem))
+    }
+
+    pub fn get_array_is_null(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<bool, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::is_null(&arr, element)
+    }
+
+    pub fn get_array_bool(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<bool, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::get_bool(&arr, element)
+    }
+
+    pub fn get_array_i32(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<i32, String> {
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_i32(&arr, elem, element)
+    }
+
+    pub fn get_array_i64(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<i64, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::get_i64(&arr, element)
+    }
+
+    pub fn get_array_f32(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<f32, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::get_f32(&arr, element)
+    }
+
+    pub fn get_array_f64(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<f64, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::get_f64(&arr, element)
+    }
+
+    pub fn get_array_str(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<String, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::get_str(&arr, element)
+    }
+
+    pub fn get_array_bytes(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<Vec<u8>, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::get_bytes(&arr, element)
+    }
+
+    pub fn get_array_date_days(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<i32, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::get_date_days(&arr, element)
+    }
+
+    pub fn get_array_time_millis(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<i32, String> {
+        let arr = get_fluss_array(row, columns, field)?;
+        array_reader::get_time_millis(&arr, element)
+    }
+
+    pub fn get_array_ts_millis(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<i64, String> {
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_ts_millis(&arr, elem, element)
+    }
+
+    pub fn get_array_ts_nanos(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<i32, String> {
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_ts_nanos(&arr, elem, element)
+    }
+
+    pub fn get_array_decimal_str(
+        row: &dyn InternalRow,
+        columns: &[fcore::metadata::Column],
+        field: usize,
+        element: usize,
+    ) -> Result<String, String> {
+        let (arr, elem) = get_array_and_elem_type(row, columns, field)?;
+        array_reader::get_decimal_str(&arr, elem, element)
+    }
+
+    pub fn get_array_element_type_id(
+        columns: &[fcore::metadata::Column],
+        field: usize,
+    ) -> Result<i32, String> {
+        let elem_type = get_array_element_type(columns, field)?;
+        Ok(crate::types::core_data_type_to_ffi(elem_type))
+    }
+}
+
+// ============================================================================
+// array_reader — low-level accessors over an already-resolved FlussArray
+//
+// Shared by the top-level `row_reader::get_array_*` wrappers and by
+// `ArrayViewInner` (which exposes recursive/nested access to C++). Keeping
+// one implementation here guarantees identical bounds-checking, error
+// messages, and type dispatch across flat and nested reads.
+// ============================================================================
+
+mod array_reader {
+    use super::fcore;
+
+    fn validate_index(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+        op: &str,
+    ) -> Result<(), String> {
+        if element < arr.size() {
+            Ok(())
+        } else {
+            Err(format!(
+                "{op}: element index out of bounds: element={element}, size={}",
+                arr.size()
+            ))
+        }
+    }
+
+    pub fn is_null(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<bool, String> {
+        validate_index(arr, element, "array_is_null")?;
+        Ok(arr.is_null_at(element))
+    }
+
+    pub fn get_bool(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<bool, String> {
+        validate_index(arr, element, "array_bool")?;
+        arr.get_boolean(element).map_err(|e| e.to_string())
+    }
+
+    pub fn get_i32(
+        arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
+        element: usize,
+    ) -> Result<i32, String> {
+        validate_index(arr, element, "array_i32")?;
+        match elem_type {
+            fcore::metadata::DataType::TinyInt(_) => arr
+                .get_byte(element)
+                .map(|v| v as i32)
+                .map_err(|e| e.to_string()),
+            fcore::metadata::DataType::SmallInt(_) => arr
+                .get_short(element)
+                .map(|v| v as i32)
+                .map_err(|e| e.to_string()),
+            _ => arr.get_int(element).map_err(|e| e.to_string()),
+        }
+    }
+
+    pub fn get_i64(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<i64, String> {
+        validate_index(arr, element, "array_i64")?;
+        arr.get_long(element).map_err(|e| e.to_string())
+    }
+
+    pub fn get_f32(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<f32, String> {
+        validate_index(arr, element, "array_f32")?;
+        arr.get_float(element).map_err(|e| e.to_string())
+    }
+
+    pub fn get_f64(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<f64, String> {
+        validate_index(arr, element, "array_f64")?;
+        arr.get_double(element).map_err(|e| e.to_string())
+    }
+
+    pub fn get_str(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<String, String> {
+        validate_index(arr, element, "array_str")?;
+        arr.get_string(element)
+            .map(|s| s.to_string())
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn get_bytes(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<Vec<u8>, String> {
+        validate_index(arr, element, "array_bytes")?;
+        arr.get_binary(element)
+            .map(|b| b.to_vec())
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn get_date_days(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<i32, String> {
+        validate_index(arr, element, "array_date")?;
+        arr.get_date(element)
+            .map(|d| d.get_inner())
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn get_time_millis(
+        arr: &fcore::row::binary_array::FlussArray,
+        element: usize,
+    ) -> Result<i32, String> {
+        validate_index(arr, element, "array_time")?;
+        arr.get_time(element)
+            .map(|t| t.get_inner())
+            .map_err(|e| e.to_string())
+    }
+
+    pub fn get_ts_millis(
+        arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
+        element: usize,
+    ) -> Result<i64, String> {
+        validate_index(arr, element, "array_ts_millis")?;
+        match elem_type {
+            fcore::metadata::DataType::TimestampLTz(ts) => arr
+                .get_timestamp_ltz(element, ts.precision())
+                .map(|v| v.get_epoch_millisecond())
+                .map_err(|e| e.to_string()),
+            fcore::metadata::DataType::Timestamp(ts) => arr
+                .get_timestamp_ntz(element, ts.precision())
+                .map(|v| v.get_millisecond())
+                .map_err(|e| e.to_string()),
+            dt => Err(format!(
+                "array_ts_millis: element type is {dt}, not timestamp"
+            )),
+        }
+    }
+
+    pub fn get_ts_nanos(
+        arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
+        element: usize,
+    ) -> Result<i32, String> {
+        validate_index(arr, element, "array_ts_nanos")?;
+        match elem_type {
+            fcore::metadata::DataType::TimestampLTz(ts) => arr
+                .get_timestamp_ltz(element, ts.precision())
+                .map(|v| v.get_nano_of_millisecond())
+                .map_err(|e| e.to_string()),
+            fcore::metadata::DataType::Timestamp(ts) => arr
+                .get_timestamp_ntz(element, ts.precision())
+                .map(|v| v.get_nano_of_millisecond())
+                .map_err(|e| e.to_string()),
+            dt => Err(format!(
+                "array_ts_nanos: element type is {dt}, not timestamp"
+            )),
+        }
+    }
+
+    pub fn get_decimal_str(
+        arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
+        element: usize,
+    ) -> Result<String, String> {
+        validate_index(arr, element, "array_decimal")?;
+        match elem_type {
+            fcore::metadata::DataType::Decimal(dd) => {
+                let decimal = arr
+                    .get_decimal(element, dd.precision(), dd.scale())
+                    .map_err(|e| e.to_string())?;
+                Ok(decimal.to_big_decimal().to_string())
+            }
+            dt => Err(format!("array_decimal: element type is {dt}, not decimal")),
+        }
+    }
+
+    pub fn get_nested_array(
+        arr: &fcore::row::binary_array::FlussArray,
+        elem_type: &fcore::metadata::DataType,
+        element: usize,
+    ) -> Result<
+        (
+            fcore::row::binary_array::FlussArray,
+            fcore::metadata::DataType,
+        ),
+        String,
+    > {
+        validate_index(arr, element, "array_nested")?;
+        match elem_type {
+            fcore::metadata::DataType::Array(at) => {
+                let nested = arr.get_array(element).map_err(|e| e.to_string())?;
+                Ok((nested, at.get_element_type().clone()))
+            }
+            dt => Err(format!("array_nested: element type is {dt}, not array")),
+        }
+    }
+}
+
+// ============================================================================
+// Macros that generate uniform sv_/lv_ array element getters (thin wrappers
+// that only forward to `row_reader::get_array_*`).
+// ============================================================================
+
+macro_rules! sv_array_element_getters {
+    ($( $method:ident, $reader_fn:ident, $ret:ty; )+) => {
+        $(
+            fn $method(
+                &self,
+                bucket: usize,
+                rec: usize,
+                field: usize,
+                element: usize,
+            ) -> Result<$ret, String> {
+                row_reader::$reader_fn(
+                    self.resolve(bucket, rec).row(),
+                    &self.columns,
+                    field,
+                    element,
+                )
+            }
+        )+
+    };
+}
+
+macro_rules! lv_array_element_getters {
+    ($( $method:ident, $reader_fn:ident, $ret:ty; )+) => {
+        $(
+            fn $method(&self, field: usize, element: usize) -> Result<$ret, String> {
+                let r = self.lv_row()?;
+                row_reader::$reader_fn(r, &self.columns, field, element)
+            }
+        )+
+    };
 }
 
 // ============================================================================
@@ -2261,6 +2929,44 @@ impl ScanResultInner {
         row_reader::get_decimal_str(self.resolve(bucket, rec).row(), &self.columns, field)
     }
 
+    fn sv_get_array_size(&self, bucket: usize, rec: usize, field: usize) -> Result<usize, String> {
+        row_reader::get_array_size(self.resolve(bucket, rec).row(), &self.columns, field)
+    }
+    sv_array_element_getters! {
+        sv_get_array_is_null, get_array_is_null, bool;
+        sv_get_array_bool,    get_array_bool,    bool;
+        sv_get_array_i32,     get_array_i32,     i32;
+        sv_get_array_i64,     get_array_i64,     i64;
+        sv_get_array_f32,     get_array_f32,     f32;
+        sv_get_array_f64,     get_array_f64,     f64;
+        sv_get_array_str,     get_array_str,     String;
+        sv_get_array_bytes,   get_array_bytes,   Vec<u8>;
+        sv_get_array_date_days,   get_array_date_days,   i32;
+        sv_get_array_time_millis, get_array_time_millis, i32;
+        sv_get_array_ts_millis,   get_array_ts_millis,   i64;
+        sv_get_array_ts_nanos,    get_array_ts_nanos,    i32;
+        sv_get_array_decimal_str, get_array_decimal_str, String;
+    }
+    fn sv_get_array_element_type(&self, field: usize) -> Result<i32, String> {
+        row_reader::get_array_element_type_id(&self.columns, field)
+    }
+    fn sv_get_array_view(
+        &self,
+        bucket: usize,
+        rec: usize,
+        field: usize,
+    ) -> Result<Box<ArrayViewInner>, String> {
+        let (arr, elem) = row_reader::get_array_and_elem_type(
+            self.resolve(bucket, rec).row(),
+            &self.columns,
+            field,
+        )?;
+        Ok(Box::new(ArrayViewInner {
+            array: arr,
+            element_type: elem.clone(),
+        }))
+    }
+
     fn sv_bucket_infos(&self) -> &Vec<ffi::FfiBucketInfo> {
         &self.bucket_infos
     }
@@ -2376,5 +3082,437 @@ impl LookupResultInner {
     fn lv_get_decimal_str(&self, field: usize) -> Result<String, String> {
         let r = self.lv_row()?;
         row_reader::get_decimal_str(r, &self.columns, field)
+    }
+    fn lv_get_array_size(&self, field: usize) -> Result<usize, String> {
+        let r = self.lv_row()?;
+        row_reader::get_array_size(r, &self.columns, field)
+    }
+    lv_array_element_getters! {
+        lv_get_array_is_null, get_array_is_null, bool;
+        lv_get_array_bool,    get_array_bool,    bool;
+        lv_get_array_i32,     get_array_i32,     i32;
+        lv_get_array_i64,     get_array_i64,     i64;
+        lv_get_array_f32,     get_array_f32,     f32;
+        lv_get_array_f64,     get_array_f64,     f64;
+        lv_get_array_str,     get_array_str,     String;
+        lv_get_array_bytes,   get_array_bytes,   Vec<u8>;
+        lv_get_array_date_days,   get_array_date_days,   i32;
+        lv_get_array_time_millis, get_array_time_millis, i32;
+        lv_get_array_ts_millis,   get_array_ts_millis,   i64;
+        lv_get_array_ts_nanos,    get_array_ts_nanos,    i32;
+        lv_get_array_decimal_str, get_array_decimal_str, String;
+    }
+    fn lv_get_array_element_type(&self, field: usize) -> Result<i32, String> {
+        row_reader::get_array_element_type_id(&self.columns, field)
+    }
+    fn lv_get_array_view(&self, field: usize) -> Result<Box<ArrayViewInner>, String> {
+        let r = self.lv_row()?;
+        let (arr, elem) = row_reader::get_array_and_elem_type(r, &self.columns, field)?;
+        Ok(Box::new(ArrayViewInner {
+            array: arr,
+            element_type: elem.clone(),
+        }))
+    }
+}
+
+// ============================================================================
+// Opaque types: ArrayViewInner (recursive array reader)
+//
+// Wraps an owned `FlussArray` plus its element `DataType` and exposes the
+// same accessors as `row_reader::get_array_*`, delegating to the shared
+// `array_reader` primitives. Enables C++ bindings to recurse into nested
+// arrays without per-level FFI scaffolding.
+// ============================================================================
+
+pub struct ArrayViewInner {
+    array: fcore::row::binary_array::FlussArray,
+    element_type: fcore::metadata::DataType,
+}
+
+impl ArrayViewInner {
+    fn av_size(&self) -> usize {
+        self.array.size()
+    }
+
+    fn av_element_type_id(&self) -> i32 {
+        crate::types::core_data_type_to_ffi(&self.element_type)
+    }
+
+    fn av_is_null(&self, element: usize) -> Result<bool, String> {
+        array_reader::is_null(&self.array, element)
+    }
+
+    fn av_get_bool(&self, element: usize) -> Result<bool, String> {
+        array_reader::get_bool(&self.array, element)
+    }
+
+    fn av_get_i32(&self, element: usize) -> Result<i32, String> {
+        array_reader::get_i32(&self.array, &self.element_type, element)
+    }
+
+    fn av_get_i64(&self, element: usize) -> Result<i64, String> {
+        array_reader::get_i64(&self.array, element)
+    }
+
+    fn av_get_f32(&self, element: usize) -> Result<f32, String> {
+        array_reader::get_f32(&self.array, element)
+    }
+
+    fn av_get_f64(&self, element: usize) -> Result<f64, String> {
+        array_reader::get_f64(&self.array, element)
+    }
+
+    fn av_get_str(&self, element: usize) -> Result<String, String> {
+        array_reader::get_str(&self.array, element)
+    }
+
+    fn av_get_bytes(&self, element: usize) -> Result<Vec<u8>, String> {
+        array_reader::get_bytes(&self.array, element)
+    }
+
+    fn av_get_date_days(&self, element: usize) -> Result<i32, String> {
+        array_reader::get_date_days(&self.array, element)
+    }
+
+    fn av_get_time_millis(&self, element: usize) -> Result<i32, String> {
+        array_reader::get_time_millis(&self.array, element)
+    }
+
+    fn av_get_ts_millis(&self, element: usize) -> Result<i64, String> {
+        array_reader::get_ts_millis(&self.array, &self.element_type, element)
+    }
+
+    fn av_get_ts_nanos(&self, element: usize) -> Result<i32, String> {
+        array_reader::get_ts_nanos(&self.array, &self.element_type, element)
+    }
+
+    fn av_get_decimal_str(&self, element: usize) -> Result<String, String> {
+        array_reader::get_decimal_str(&self.array, &self.element_type, element)
+    }
+
+    fn av_get_nested(&self, element: usize) -> Result<Box<ArrayViewInner>, String> {
+        let (arr, elem) = array_reader::get_nested_array(&self.array, &self.element_type, element)?;
+        Ok(Box::new(ArrayViewInner {
+            array: arr,
+            element_type: elem,
+        }))
+    }
+}
+
+// ============================================================================
+// Opaque types: ArrayWriterInner (array builder for writes)
+// ============================================================================
+
+pub struct ArrayWriterInner {
+    writer: Option<fcore::row::binary_array::FlussArrayWriter>,
+    completed: Option<fcore::row::binary_array::FlussArray>,
+    element_type: fcore::metadata::DataType,
+    num_elements: usize,
+}
+
+fn new_array_writer(
+    size: usize,
+    element_leaf_type_id: i32,
+    precision: u32,
+    scale: u32,
+    array_nesting: u32,
+) -> Result<Box<ArrayWriterInner>, String> {
+    let element_type =
+        types::element_type_from_ffi(element_leaf_type_id, precision, scale, array_nesting)
+            .map_err(|e| e.to_string())?;
+    let writer = fcore::row::binary_array::FlussArrayWriter::new(size, &element_type);
+    Ok(Box::new(ArrayWriterInner {
+        writer: Some(writer),
+        completed: None,
+        element_type,
+        num_elements: size,
+    }))
+}
+
+impl ArrayWriterInner {
+    fn writer_mut(&mut self) -> Result<&mut fcore::row::binary_array::FlussArrayWriter, String> {
+        self.writer
+            .as_mut()
+            .ok_or_else(|| "ArrayWriter is already finalized".to_string())
+    }
+
+    fn validate_index(&self, idx: usize) -> Result<(), String> {
+        if idx < self.num_elements {
+            Ok(())
+        } else {
+            Err(format!(
+                "ArrayWriter index out of bounds: idx={idx}, size={}",
+                self.num_elements
+            ))
+        }
+    }
+
+    fn complete_if_needed(&mut self) -> Result<(), String> {
+        if self.completed.is_none() {
+            let w = self
+                .writer
+                .take()
+                .ok_or_else(|| "ArrayWriter has already been finalized".to_string())?;
+            self.completed = Some(w.complete().map_err(|e| e.to_string())?);
+        }
+        Ok(())
+    }
+
+    /// Checks writer liveness first, then the element index. Returning the
+    /// clearest finalization error before a bounds error keeps diagnostics
+    /// aligned with the caller's intent when a writer is misused after
+    /// completion.
+    fn ensure_writable(&self, idx: usize) -> Result<(), String> {
+        if self.writer.is_none() {
+            return Err("ArrayWriter is already finalized".to_string());
+        }
+        self.validate_index(idx)
+    }
+
+    fn aw_set_null(&mut self, idx: usize) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        self.writer_mut()?.set_null_at(idx);
+        Ok(())
+    }
+
+    fn aw_set_bool(&mut self, idx: usize, val: bool) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        if !matches!(self.element_type, fcore::metadata::DataType::Boolean(_)) {
+            return Err(format!(
+                "ArrayWriter type mismatch: expected BOOLEAN element, got {}",
+                self.element_type
+            ));
+        }
+        self.writer_mut()?.write_boolean(idx, val);
+        Ok(())
+    }
+
+    fn aw_set_i32(&mut self, idx: usize, val: i32) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        match &self.element_type {
+            fcore::metadata::DataType::TinyInt(_) => {
+                let v = i8::try_from(val)
+                    .map_err(|_| format!("Value {val} does not fit TINYINT element"))?;
+                self.writer_mut()?.write_byte(idx, v);
+            }
+            fcore::metadata::DataType::SmallInt(_) => {
+                let v = i16::try_from(val)
+                    .map_err(|_| format!("Value {val} does not fit SMALLINT element"))?;
+                self.writer_mut()?.write_short(idx, v);
+            }
+            fcore::metadata::DataType::Int(_) => {
+                self.writer_mut()?.write_int(idx, val);
+            }
+            _ => {
+                return Err(format!(
+                    "ArrayWriter type mismatch: expected TINYINT/SMALLINT/INT element, got {}",
+                    self.element_type
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn aw_set_i64(&mut self, idx: usize, val: i64) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        if !matches!(self.element_type, fcore::metadata::DataType::BigInt(_)) {
+            return Err(format!(
+                "ArrayWriter type mismatch: expected BIGINT element, got {}",
+                self.element_type
+            ));
+        }
+        self.writer_mut()?.write_long(idx, val);
+        Ok(())
+    }
+
+    fn aw_set_f32(&mut self, idx: usize, val: f32) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        if !matches!(self.element_type, fcore::metadata::DataType::Float(_)) {
+            return Err(format!(
+                "ArrayWriter type mismatch: expected FLOAT element, got {}",
+                self.element_type
+            ));
+        }
+        self.writer_mut()?.write_float(idx, val);
+        Ok(())
+    }
+
+    fn aw_set_f64(&mut self, idx: usize, val: f64) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        if !matches!(self.element_type, fcore::metadata::DataType::Double(_)) {
+            return Err(format!(
+                "ArrayWriter type mismatch: expected DOUBLE element, got {}",
+                self.element_type
+            ));
+        }
+        self.writer_mut()?.write_double(idx, val);
+        Ok(())
+    }
+
+    fn aw_set_str(&mut self, idx: usize, val: &str) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        if !matches!(
+            self.element_type,
+            fcore::metadata::DataType::String(_) | fcore::metadata::DataType::Char(_)
+        ) {
+            return Err(format!(
+                "ArrayWriter type mismatch: expected STRING/CHAR element, got {}",
+                self.element_type
+            ));
+        }
+        self.writer_mut()?.write_string(idx, val);
+        Ok(())
+    }
+
+    fn aw_set_bytes(&mut self, idx: usize, val: &[u8]) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        if !matches!(
+            self.element_type,
+            fcore::metadata::DataType::Bytes(_) | fcore::metadata::DataType::Binary(_)
+        ) {
+            return Err(format!(
+                "ArrayWriter type mismatch: expected BYTES/BINARY element, got {}",
+                self.element_type
+            ));
+        }
+        self.writer_mut()?.write_binary_bytes(idx, val);
+        Ok(())
+    }
+
+    fn aw_set_date(&mut self, idx: usize, days: i32) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        if !matches!(self.element_type, fcore::metadata::DataType::Date(_)) {
+            return Err(format!(
+                "ArrayWriter type mismatch: expected DATE element, got {}",
+                self.element_type
+            ));
+        }
+        self.writer_mut()?
+            .write_date(idx, fcore::row::Date::new(days));
+        Ok(())
+    }
+
+    fn aw_set_time(&mut self, idx: usize, millis: i32) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        if !matches!(self.element_type, fcore::metadata::DataType::Time(_)) {
+            return Err(format!(
+                "ArrayWriter type mismatch: expected TIME element, got {}",
+                self.element_type
+            ));
+        }
+        self.writer_mut()?
+            .write_time(idx, fcore::row::Time::new(millis));
+        Ok(())
+    }
+
+    fn aw_set_ts_ntz(&mut self, idx: usize, millis: i64, nanos: i32) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        let precision = match &self.element_type {
+            fcore::metadata::DataType::Timestamp(ts) => ts.precision(),
+            _ => {
+                return Err(format!(
+                    "ArrayWriter type mismatch: expected TIMESTAMP element, got {}",
+                    self.element_type
+                ));
+            }
+        };
+        let ts = fcore::row::TimestampNtz::from_millis_nanos(millis, nanos)
+            .map_err(|e| e.to_string())?;
+        self.writer_mut()?.write_timestamp_ntz(idx, &ts, precision);
+        Ok(())
+    }
+
+    fn aw_set_ts_ltz(&mut self, idx: usize, millis: i64, nanos: i32) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        let precision = match &self.element_type {
+            fcore::metadata::DataType::TimestampLTz(ts) => ts.precision(),
+            _ => {
+                return Err(format!(
+                    "ArrayWriter type mismatch: expected TIMESTAMP_LTZ element, got {}",
+                    self.element_type
+                ));
+            }
+        };
+        let ts = fcore::row::TimestampLtz::from_millis_nanos(millis, nanos)
+            .map_err(|e| e.to_string())?;
+        self.writer_mut()?.write_timestamp_ltz(idx, &ts, precision);
+        Ok(())
+    }
+
+    fn aw_set_decimal_str(&mut self, idx: usize, val: &str) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        let (precision, scale) = match &self.element_type {
+            fcore::metadata::DataType::Decimal(d) => (d.precision(), d.scale()),
+            _ => {
+                return Err(format!(
+                    "ArrayWriter type mismatch: expected DECIMAL element, got {}",
+                    self.element_type
+                ));
+            }
+        };
+        let bd = bigdecimal::BigDecimal::from_str(val).map_err(|e| e.to_string())?;
+        let decimal = fcore::row::Decimal::from_big_decimal(bd, precision, scale)
+            .map_err(|e| e.to_string())?;
+        self.writer_mut()?.write_decimal(idx, &decimal, precision);
+        Ok(())
+    }
+
+    fn aw_set_array(&mut self, idx: usize, nested: &mut ArrayWriterInner) -> Result<(), String> {
+        self.ensure_writable(idx)?;
+        let expected_inner = match &self.element_type {
+            fcore::metadata::DataType::Array(at) => at.get_element_type(),
+            _ => {
+                return Err(format!(
+                    "ArrayWriter type mismatch: expected ARRAY element, got {}",
+                    self.element_type
+                ));
+            }
+        };
+        if !structurally_compatible(expected_inner, &nested.element_type) {
+            return Err(format!(
+                "Nested ArrayWriter type mismatch: expected nested element type {}, got {}",
+                expected_inner, nested.element_type
+            ));
+        }
+        nested.complete_if_needed()?;
+        // After `complete_if_needed()?` succeeds, `completed` is guaranteed `Some`.
+        let arr = nested
+            .completed
+            .as_ref()
+            .expect("ArrayWriterInner::completed should be populated after complete_if_needed");
+        self.writer_mut()?.write_array(idx, arr);
+        Ok(())
+    }
+}
+
+/// Structural type equivalence that ignores nullability flags but preserves
+/// variant and precision/scale semantics. Used to compare ArrayWriter element
+/// types on the binding boundary, where C++ callers never control nullability
+/// explicitly.
+fn structurally_compatible(a: &fcore::metadata::DataType, b: &fcore::metadata::DataType) -> bool {
+    use fcore::metadata::DataType;
+    match (a, b) {
+        (DataType::Boolean(_), DataType::Boolean(_))
+        | (DataType::TinyInt(_), DataType::TinyInt(_))
+        | (DataType::SmallInt(_), DataType::SmallInt(_))
+        | (DataType::Int(_), DataType::Int(_))
+        | (DataType::BigInt(_), DataType::BigInt(_))
+        | (DataType::Float(_), DataType::Float(_))
+        | (DataType::Double(_), DataType::Double(_))
+        | (DataType::String(_), DataType::String(_))
+        | (DataType::Bytes(_), DataType::Bytes(_))
+        | (DataType::Date(_), DataType::Date(_))
+        | (DataType::Time(_), DataType::Time(_)) => true,
+        (DataType::Timestamp(x), DataType::Timestamp(y)) => x.precision() == y.precision(),
+        (DataType::TimestampLTz(x), DataType::TimestampLTz(y)) => x.precision() == y.precision(),
+        (DataType::Char(x), DataType::Char(y)) => x.length() == y.length(),
+        (DataType::Binary(x), DataType::Binary(y)) => x.length() == y.length(),
+        (DataType::Decimal(x), DataType::Decimal(y)) => {
+            x.precision() == y.precision() && x.scale() == y.scale()
+        }
+        (DataType::Array(x), DataType::Array(y)) => {
+            structurally_compatible(x.get_element_type(), y.get_element_type())
+        }
+        _ => false,
     }
 }

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -404,6 +404,7 @@ mod ffi {
             scale: u32,
             array_nesting: u32,
         ) -> Result<Box<ArrayWriterInner>>;
+        fn aw_size(self: &ArrayWriterInner) -> usize;
         fn aw_set_null(self: &mut ArrayWriterInner, idx: usize) -> Result<()>;
         fn aw_set_bool(self: &mut ArrayWriterInner, idx: usize, val: bool) -> Result<()>;
         fn aw_set_i32(self: &mut ArrayWriterInner, idx: usize, val: i32) -> Result<()>;
@@ -3385,6 +3386,10 @@ impl ArrayWriterInner {
             return Err("ArrayWriter is already finalized".to_string());
         }
         self.validate_index(idx)
+    }
+
+    fn aw_size(&self) -> usize {
+        self.num_elements
     }
 
     fn aw_set_null(&mut self, idx: usize) -> Result<(), String> {

--- a/bindings/cpp/src/table.cpp
+++ b/bindings/cpp/src/table.cpp
@@ -181,6 +181,7 @@ void ArrayWriter::SetArray(size_t idx, ArrayWriter&& nested) {
         throw std::logic_error("ArrayWriter::SetArray: nested writer not available");
     }
     inner_->aw_set_array(idx, *nested.inner_);
+    nested.Destroy();
 }
 
 // ============================================================================
@@ -411,6 +412,7 @@ void GenericRow::SetArray(size_t idx, ArrayWriter&& writer) {
         throw std::logic_error("GenericRow::SetArray: ArrayWriter not available");
     }
     inner_->gr_set_array(idx, *writer.inner_);
+    writer.Destroy();
 }
 
 // ============================================================================

--- a/bindings/cpp/src/table.cpp
+++ b/bindings/cpp/src/table.cpp
@@ -19,6 +19,7 @@
 
 #include <arrow/c/bridge.h>
 
+#include <cassert>
 #include <ctime>
 
 #include "ffi_converter.hpp"
@@ -127,6 +128,11 @@ ArrayWriter& ArrayWriter::operator=(ArrayWriter&& other) noexcept {
 
 bool ArrayWriter::Available() const { return inner_ != nullptr; }
 
+size_t ArrayWriter::Size() const noexcept {
+    assert(inner_ && "ArrayWriter::Size called on moved-from instance");
+    return inner_->aw_size();
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CHECK_AW(name)                                                                    \
     do {                                                                                  \
@@ -214,13 +220,13 @@ ArrayView& ArrayView::operator=(ArrayView&& other) noexcept {
         if (!inner_) throw std::logic_error("ArrayView: not available (moved-from)");  \
     } while (0)
 
-size_t ArrayView::Size() const {
-    CHECK_AV();
+size_t ArrayView::Size() const noexcept {
+    assert(inner_ && "ArrayView::Size called on moved-from instance");
     return inner_->av_size();
 }
 
-TypeId ArrayView::ElementType() const {
-    CHECK_AV();
+TypeId ArrayView::ElementType() const noexcept {
+    assert(inner_ && "ArrayView::ElementType called on moved-from instance");
     return static_cast<TypeId>(inner_->av_element_type_id());
 }
 

--- a/bindings/cpp/src/table.cpp
+++ b/bindings/cpp/src/table.cpp
@@ -260,7 +260,8 @@ std::string ArrayView::GetString(size_t element) const {
 
 std::vector<uint8_t> ArrayView::GetBytes(size_t element) const {
     CHECK_AV();
-    return inner_->av_get_bytes(element);
+    auto rv = inner_->av_get_bytes(element);
+    return {rv.data(), rv.data() + rv.size()};
 }
 
 fluss::Date ArrayView::GetDate(size_t element) const {
@@ -546,7 +547,8 @@ std::string RowView::GetArrayString(size_t idx, size_t element) const {
 
 std::vector<uint8_t> RowView::GetArrayBytes(size_t idx, size_t element) const {
     CHECK_DATA("RowView");
-    return data_->raw->sv_get_array_bytes(bucket_idx_, rec_idx_, idx, element);
+    auto rv = data_->raw->sv_get_array_bytes(bucket_idx_, rec_idx_, idx, element);
+    return {rv.data(), rv.data() + rv.size()};
 }
 
 fluss::Date RowView::GetArrayDate(size_t idx, size_t element) const {
@@ -830,7 +832,8 @@ std::string LookupResult::GetArrayString(size_t idx, size_t element) const {
 
 std::vector<uint8_t> LookupResult::GetArrayBytes(size_t idx, size_t element) const {
     CHECK_INNER("LookupResult");
-    return inner_->lv_get_array_bytes(idx, element);
+    auto rv = inner_->lv_get_array_bytes(idx, element);
+    return {rv.data(), rv.data() + rv.size()};
 }
 
 fluss::Date LookupResult::GetArrayDate(size_t idx, size_t element) const {

--- a/bindings/cpp/src/table.cpp
+++ b/bindings/cpp/src/table.cpp
@@ -86,6 +86,219 @@ int Date::Day() const {
     } while (0)
 
 // ============================================================================
+// ArrayWriter — builder for array values backed by Rust ArrayWriterInner
+// ============================================================================
+
+ArrayWriter::ArrayWriter(size_t size, DataType element_type) : element_type_(std::move(element_type)) {
+    auto flat = utils::flatten_array_type(element_type_);
+    int32_t leaf_type_id = flat.nesting > 0 ? flat.leaf_type : static_cast<int32_t>(element_type_.id());
+    uint32_t leaf_precision = static_cast<uint32_t>(flat.nesting > 0 ? flat.leaf_precision
+                                                                      : element_type_.precision());
+    uint32_t leaf_scale = static_cast<uint32_t>(flat.nesting > 0 ? flat.leaf_scale : element_type_.scale());
+    uint32_t array_nesting = static_cast<uint32_t>(flat.nesting);
+
+    auto box = ffi::new_array_writer(size, leaf_type_id, leaf_precision, leaf_scale, array_nesting);
+    inner_ = box.into_raw();
+}
+
+ArrayWriter::~ArrayWriter() noexcept { Destroy(); }
+
+void ArrayWriter::Destroy() noexcept {
+    if (inner_) {
+        rust::Box<ffi::ArrayWriterInner>::from_raw(inner_);
+        inner_ = nullptr;
+    }
+}
+
+ArrayWriter::ArrayWriter(ArrayWriter&& other) noexcept
+    : inner_(other.inner_), element_type_(std::move(other.element_type_)) {
+    other.inner_ = nullptr;
+}
+
+ArrayWriter& ArrayWriter::operator=(ArrayWriter&& other) noexcept {
+    if (this != &other) {
+        Destroy();
+        inner_ = other.inner_;
+        element_type_ = std::move(other.element_type_);
+        other.inner_ = nullptr;
+    }
+    return *this;
+}
+
+bool ArrayWriter::Available() const { return inner_ != nullptr; }
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define CHECK_AW(name)                                                                    \
+    do {                                                                                  \
+        if (!inner_) throw std::logic_error(name ": not available (moved-from or null)"); \
+    } while (0)
+
+void ArrayWriter::SetNull(size_t idx) { CHECK_AW("ArrayWriter"); inner_->aw_set_null(idx); }
+void ArrayWriter::SetBool(size_t idx, bool v) { CHECK_AW("ArrayWriter"); inner_->aw_set_bool(idx, v); }
+void ArrayWriter::SetInt32(size_t idx, int32_t v) { CHECK_AW("ArrayWriter"); inner_->aw_set_i32(idx, v); }
+void ArrayWriter::SetInt64(size_t idx, int64_t v) { CHECK_AW("ArrayWriter"); inner_->aw_set_i64(idx, v); }
+void ArrayWriter::SetFloat32(size_t idx, float v) { CHECK_AW("ArrayWriter"); inner_->aw_set_f32(idx, v); }
+void ArrayWriter::SetFloat64(size_t idx, double v) { CHECK_AW("ArrayWriter"); inner_->aw_set_f64(idx, v); }
+
+void ArrayWriter::SetString(size_t idx, const std::string& v) {
+    CHECK_AW("ArrayWriter");
+    inner_->aw_set_str(idx, v);
+}
+
+void ArrayWriter::SetBytes(size_t idx, const std::vector<uint8_t>& v) {
+    CHECK_AW("ArrayWriter");
+    inner_->aw_set_bytes(idx, rust::Slice<const uint8_t>(v.data(), v.size()));
+}
+
+void ArrayWriter::SetDate(size_t idx, fluss::Date d) {
+    CHECK_AW("ArrayWriter");
+    inner_->aw_set_date(idx, d.days_since_epoch);
+}
+
+void ArrayWriter::SetTime(size_t idx, fluss::Time t) {
+    CHECK_AW("ArrayWriter");
+    inner_->aw_set_time(idx, t.millis_since_midnight);
+}
+
+void ArrayWriter::SetTimestampNtz(size_t idx, fluss::Timestamp ts) {
+    CHECK_AW("ArrayWriter");
+    inner_->aw_set_ts_ntz(idx, ts.epoch_millis, ts.nano_of_millisecond);
+}
+
+void ArrayWriter::SetTimestampLtz(size_t idx, fluss::Timestamp ts) {
+    CHECK_AW("ArrayWriter");
+    inner_->aw_set_ts_ltz(idx, ts.epoch_millis, ts.nano_of_millisecond);
+}
+
+void ArrayWriter::SetDecimal(size_t idx, const std::string& value) {
+    CHECK_AW("ArrayWriter");
+    inner_->aw_set_decimal_str(idx, value);
+}
+
+void ArrayWriter::SetArray(size_t idx, ArrayWriter&& nested) {
+    CHECK_AW("ArrayWriter");
+    if (!nested.inner_) {
+        throw std::logic_error("ArrayWriter::SetArray: nested writer not available");
+    }
+    inner_->aw_set_array(idx, *nested.inner_);
+}
+
+// ============================================================================
+// ArrayView — read-only recursive view into an array column value
+// ============================================================================
+
+ArrayView::~ArrayView() noexcept { Destroy(); }
+
+void ArrayView::Destroy() noexcept {
+    if (inner_) {
+        rust::Box<ffi::ArrayViewInner>::from_raw(inner_);
+        inner_ = nullptr;
+    }
+}
+
+ArrayView::ArrayView(ArrayView&& other) noexcept : inner_(other.inner_) { other.inner_ = nullptr; }
+
+ArrayView& ArrayView::operator=(ArrayView&& other) noexcept {
+    if (this != &other) {
+        Destroy();
+        inner_ = other.inner_;
+        other.inner_ = nullptr;
+    }
+    return *this;
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define CHECK_AV()                                                                      \
+    do {                                                                                \
+        if (!inner_) throw std::logic_error("ArrayView: not available (moved-from)");  \
+    } while (0)
+
+size_t ArrayView::Size() const {
+    CHECK_AV();
+    return inner_->av_size();
+}
+
+TypeId ArrayView::ElementType() const {
+    CHECK_AV();
+    return static_cast<TypeId>(inner_->av_element_type_id());
+}
+
+bool ArrayView::IsNull(size_t element) const {
+    CHECK_AV();
+    return inner_->av_is_null(element);
+}
+
+bool ArrayView::GetBool(size_t element) const {
+    CHECK_AV();
+    return inner_->av_get_bool(element);
+}
+
+int32_t ArrayView::GetInt32(size_t element) const {
+    CHECK_AV();
+    return inner_->av_get_i32(element);
+}
+
+int64_t ArrayView::GetInt64(size_t element) const {
+    CHECK_AV();
+    return inner_->av_get_i64(element);
+}
+
+float ArrayView::GetFloat32(size_t element) const {
+    CHECK_AV();
+    return inner_->av_get_f32(element);
+}
+
+double ArrayView::GetFloat64(size_t element) const {
+    CHECK_AV();
+    return inner_->av_get_f64(element);
+}
+
+std::string ArrayView::GetString(size_t element) const {
+    CHECK_AV();
+    return std::string(inner_->av_get_str(element));
+}
+
+std::vector<uint8_t> ArrayView::GetBytes(size_t element) const {
+    CHECK_AV();
+    return inner_->av_get_bytes(element);
+}
+
+fluss::Date ArrayView::GetDate(size_t element) const {
+    CHECK_AV();
+    return fluss::Date{inner_->av_get_date_days(element)};
+}
+
+fluss::Time ArrayView::GetTime(size_t element) const {
+    CHECK_AV();
+    return fluss::Time{inner_->av_get_time_millis(element)};
+}
+
+fluss::Timestamp ArrayView::GetTimestampNtz(size_t element) const {
+    CHECK_AV();
+    return fluss::Timestamp{inner_->av_get_ts_millis(element),
+                            inner_->av_get_ts_nanos(element)};
+}
+
+fluss::Timestamp ArrayView::GetTimestampLtz(size_t element) const {
+    CHECK_AV();
+    return fluss::Timestamp{inner_->av_get_ts_millis(element),
+                            inner_->av_get_ts_nanos(element)};
+}
+
+std::string ArrayView::GetDecimalString(size_t element) const {
+    CHECK_AV();
+    return std::string(inner_->av_get_decimal_str(element));
+}
+
+ArrayView ArrayView::GetArray(size_t element) const {
+    CHECK_AV();
+    auto box = inner_->av_get_nested(element);
+    return ArrayView(box.into_raw());
+}
+
+#undef CHECK_AV
+
+// ============================================================================
 // GenericRow — write-only row backed by opaque Rust GenericRowInner
 // ============================================================================
 
@@ -191,6 +404,14 @@ void GenericRow::SetDecimal(size_t idx, const std::string& value) {
     inner_->gr_set_decimal_str(idx, value);
 }
 
+void GenericRow::SetArray(size_t idx, ArrayWriter&& writer) {
+    CHECK_INNER("GenericRow");
+    if (!writer.inner_) {
+        throw std::logic_error("GenericRow::SetArray: ArrayWriter not available");
+    }
+    inner_->gr_set_array(idx, *writer.inner_);
+}
+
 // ============================================================================
 // ScanData — destructor must live in .cpp where rust::Box is visible
 // ============================================================================
@@ -276,6 +497,84 @@ bool RowView::IsDecimal(size_t idx) const { return GetType(idx) == TypeId::Decim
 std::string RowView::GetDecimalString(size_t idx) const {
     CHECK_DATA("RowView");
     return std::string(data_->raw->sv_get_decimal_str(bucket_idx_, rec_idx_, idx));
+}
+
+size_t RowView::GetArraySize(size_t idx) const {
+    CHECK_DATA("RowView");
+    return data_->raw->sv_get_array_size(bucket_idx_, rec_idx_, idx);
+}
+
+TypeId RowView::GetArrayElementType(size_t idx) const {
+    CHECK_DATA("RowView");
+    return static_cast<TypeId>(data_->raw->sv_get_array_element_type(idx));
+}
+
+bool RowView::IsArrayElementNull(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return data_->raw->sv_get_array_is_null(bucket_idx_, rec_idx_, idx, element);
+}
+
+bool RowView::GetArrayBool(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return data_->raw->sv_get_array_bool(bucket_idx_, rec_idx_, idx, element);
+}
+
+int32_t RowView::GetArrayInt32(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return data_->raw->sv_get_array_i32(bucket_idx_, rec_idx_, idx, element);
+}
+
+int64_t RowView::GetArrayInt64(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return data_->raw->sv_get_array_i64(bucket_idx_, rec_idx_, idx, element);
+}
+
+float RowView::GetArrayFloat32(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return data_->raw->sv_get_array_f32(bucket_idx_, rec_idx_, idx, element);
+}
+
+double RowView::GetArrayFloat64(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return data_->raw->sv_get_array_f64(bucket_idx_, rec_idx_, idx, element);
+}
+
+std::string RowView::GetArrayString(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return std::string(data_->raw->sv_get_array_str(bucket_idx_, rec_idx_, idx, element));
+}
+
+std::vector<uint8_t> RowView::GetArrayBytes(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return data_->raw->sv_get_array_bytes(bucket_idx_, rec_idx_, idx, element);
+}
+
+fluss::Date RowView::GetArrayDate(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return fluss::Date{data_->raw->sv_get_array_date_days(bucket_idx_, rec_idx_, idx, element)};
+}
+
+fluss::Time RowView::GetArrayTime(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return fluss::Time{data_->raw->sv_get_array_time_millis(bucket_idx_, rec_idx_, idx, element)};
+}
+
+fluss::Timestamp RowView::GetArrayTimestamp(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    auto millis = data_->raw->sv_get_array_ts_millis(bucket_idx_, rec_idx_, idx, element);
+    auto nanos = data_->raw->sv_get_array_ts_nanos(bucket_idx_, rec_idx_, idx, element);
+    return fluss::Timestamp{millis, nanos};
+}
+
+std::string RowView::GetArrayDecimalString(size_t idx, size_t element) const {
+    CHECK_DATA("RowView");
+    return std::string(data_->raw->sv_get_array_decimal_str(bucket_idx_, rec_idx_, idx, element));
+}
+
+ArrayView RowView::GetArrayView(size_t idx) const {
+    CHECK_DATA("RowView");
+    auto box = data_->raw->sv_get_array_view(bucket_idx_, rec_idx_, idx);
+    return ArrayView(box.into_raw());
 }
 
 // ============================================================================
@@ -482,6 +781,84 @@ bool LookupResult::IsDecimal(size_t idx) const { return GetType(idx) == TypeId::
 std::string LookupResult::GetDecimalString(size_t idx) const {
     CHECK_INNER("LookupResult");
     return std::string(inner_->lv_get_decimal_str(idx));
+}
+
+size_t LookupResult::GetArraySize(size_t idx) const {
+    CHECK_INNER("LookupResult");
+    return inner_->lv_get_array_size(idx);
+}
+
+TypeId LookupResult::GetArrayElementType(size_t idx) const {
+    CHECK_INNER("LookupResult");
+    return static_cast<TypeId>(inner_->lv_get_array_element_type(idx));
+}
+
+bool LookupResult::IsArrayElementNull(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return inner_->lv_get_array_is_null(idx, element);
+}
+
+bool LookupResult::GetArrayBool(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return inner_->lv_get_array_bool(idx, element);
+}
+
+int32_t LookupResult::GetArrayInt32(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return inner_->lv_get_array_i32(idx, element);
+}
+
+int64_t LookupResult::GetArrayInt64(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return inner_->lv_get_array_i64(idx, element);
+}
+
+float LookupResult::GetArrayFloat32(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return inner_->lv_get_array_f32(idx, element);
+}
+
+double LookupResult::GetArrayFloat64(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return inner_->lv_get_array_f64(idx, element);
+}
+
+std::string LookupResult::GetArrayString(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return std::string(inner_->lv_get_array_str(idx, element));
+}
+
+std::vector<uint8_t> LookupResult::GetArrayBytes(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return inner_->lv_get_array_bytes(idx, element);
+}
+
+fluss::Date LookupResult::GetArrayDate(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return fluss::Date{inner_->lv_get_array_date_days(idx, element)};
+}
+
+fluss::Time LookupResult::GetArrayTime(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return fluss::Time{inner_->lv_get_array_time_millis(idx, element)};
+}
+
+fluss::Timestamp LookupResult::GetArrayTimestamp(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    auto millis = inner_->lv_get_array_ts_millis(idx, element);
+    auto nanos = inner_->lv_get_array_ts_nanos(idx, element);
+    return fluss::Timestamp{millis, nanos};
+}
+
+std::string LookupResult::GetArrayDecimalString(size_t idx, size_t element) const {
+    CHECK_INNER("LookupResult");
+    return std::string(inner_->lv_get_array_decimal_str(idx, element));
+}
+
+ArrayView LookupResult::GetArrayView(size_t idx) const {
+    CHECK_INNER("LookupResult");
+    auto box = inner_->lv_get_array_view(idx);
+    return ArrayView(box.into_raw());
 }
 
 // ============================================================================

--- a/bindings/cpp/src/types.rs
+++ b/bindings/cpp/src/types.rs
@@ -39,10 +39,76 @@ pub const DATA_TYPE_TIMESTAMP_LTZ: i32 = 13;
 pub const DATA_TYPE_DECIMAL: i32 = 14;
 pub const DATA_TYPE_CHAR: i32 = 15;
 pub const DATA_TYPE_BINARY: i32 = 16;
+pub const DATA_TYPE_ARRAY: i32 = 17;
 
-// DATUM_TYPE_* constants removed — no longer needed with opaque types.
+fn ffi_column_to_core_data_type(col: &ffi::FfiColumn) -> Result<fcore::metadata::DataType> {
+    ffi_data_type_to_core(
+        col.data_type,
+        col.precision as u32,
+        col.scale as u32,
+        col.element_data_type,
+        col.element_precision as u32,
+        col.element_scale as u32,
+        col.array_nesting.max(0) as u32,
+    )
+}
 
-fn ffi_data_type_to_core(dt: i32, precision: u32, scale: u32) -> Result<fcore::metadata::DataType> {
+fn type_precision_scale(dt: &fcore::metadata::DataType) -> (i32, i32) {
+    match dt {
+        fcore::metadata::DataType::Decimal(d) => (d.precision() as i32, d.scale() as i32),
+        fcore::metadata::DataType::Timestamp(ts) => (ts.precision() as i32, 0),
+        fcore::metadata::DataType::TimestampLTz(ts) => (ts.precision() as i32, 0),
+        fcore::metadata::DataType::Char(ch) => (ch.length() as i32, 0),
+        fcore::metadata::DataType::Binary(bin) => (bin.length() as i32, 0),
+        _ => (0, 0),
+    }
+}
+
+fn flatten_array_leaf_type(dt: &fcore::metadata::DataType) -> Result<(i32, i32, i32, i32)> {
+    let mut nesting = 0_i32;
+    let mut leaf = dt;
+    while let fcore::metadata::DataType::Array(at) = leaf {
+        nesting += 1;
+        leaf = at.get_element_type();
+    }
+    if nesting == 0 {
+        return Err(anyhow!("Expected ARRAY data type, got {dt}"));
+    }
+    let leaf_type = core_data_type_to_ffi(leaf);
+    if leaf_type == 0 {
+        return Err(anyhow!(
+            "Unsupported ARRAY leaf type for C++ bindings: {leaf}"
+        ));
+    }
+    let (leaf_precision, leaf_scale) = type_precision_scale(leaf);
+    Ok((nesting, leaf_type, leaf_precision, leaf_scale))
+}
+
+fn build_array_type_from_leaf(
+    leaf_dt: i32,
+    leaf_precision: u32,
+    leaf_scale: u32,
+    nesting: u32,
+) -> Result<fcore::metadata::DataType> {
+    if nesting == 0 {
+        return Err(anyhow!("ARRAY nesting must be >= 1"));
+    }
+    let mut dt = ffi_data_type_to_core(leaf_dt, leaf_precision, leaf_scale, 0, 0, 0, 0)?;
+    for _ in 0..nesting {
+        dt = fcore::metadata::DataTypes::array(dt);
+    }
+    Ok(dt)
+}
+
+fn ffi_data_type_to_core(
+    dt: i32,
+    precision: u32,
+    scale: u32,
+    element_dt: i32,
+    element_precision: u32,
+    element_scale: u32,
+    array_nesting: u32,
+) -> Result<fcore::metadata::DataType> {
     match dt {
         DATA_TYPE_BOOLEAN => Ok(fcore::metadata::DataTypes::boolean()),
         DATA_TYPE_TINYINT => Ok(fcore::metadata::DataTypes::tinyint()),
@@ -67,6 +133,31 @@ fn ffi_data_type_to_core(dt: i32, precision: u32, scale: u32) -> Result<fcore::m
         }
         DATA_TYPE_CHAR => Ok(fcore::metadata::DataTypes::char(precision)),
         DATA_TYPE_BINARY => Ok(fcore::metadata::DataTypes::binary(precision as usize)),
+        DATA_TYPE_ARRAY => {
+            if array_nesting > 0 {
+                build_array_type_from_leaf(
+                    element_dt,
+                    element_precision,
+                    element_scale,
+                    array_nesting,
+                )
+            } else {
+                // Backward compatibility for older one-level metadata.
+                if element_dt == 0 {
+                    return Err(anyhow!("ARRAY requires element type metadata"));
+                }
+                let element_type = ffi_data_type_to_core(
+                    element_dt,
+                    element_precision,
+                    element_scale,
+                    0,
+                    0,
+                    0,
+                    0,
+                )?;
+                Ok(fcore::metadata::DataTypes::array(element_type))
+            }
+        }
         _ => Err(anyhow!("Unknown data type: {dt}")),
     }
 }
@@ -89,7 +180,32 @@ pub fn core_data_type_to_ffi(dt: &fcore::metadata::DataType) -> i32 {
         fcore::metadata::DataType::Decimal(_) => DATA_TYPE_DECIMAL,
         fcore::metadata::DataType::Char(_) => DATA_TYPE_CHAR,
         fcore::metadata::DataType::Binary(_) => DATA_TYPE_BINARY,
+        fcore::metadata::DataType::Array(_) => DATA_TYPE_ARRAY,
         _ => 0,
+    }
+}
+
+fn core_column_to_ffi(col: &fcore::metadata::Column) -> ffi::FfiColumn {
+    let (precision, scale) = type_precision_scale(col.data_type());
+
+    let (array_nesting, element_data_type, element_precision, element_scale) = match col.data_type()
+    {
+        fcore::metadata::DataType::Array(_) => {
+            flatten_array_leaf_type(col.data_type()).unwrap_or((0, 0, 0, 0))
+        }
+        _ => (0, 0, 0, 0),
+    };
+
+    ffi::FfiColumn {
+        name: col.name().to_string(),
+        data_type: core_data_type_to_ffi(col.data_type()),
+        comment: col.comment().unwrap_or("").to_string(),
+        precision,
+        scale,
+        array_nesting,
+        element_data_type,
+        element_precision,
+        element_scale,
     }
 }
 
@@ -99,13 +215,13 @@ pub fn ffi_descriptor_to_core(
     let mut schema_builder = fcore::metadata::Schema::builder();
 
     for col in &descriptor.schema.columns {
-        if col.precision < 0 || col.scale < 0 {
+        if col.precision < 0 || col.scale < 0 || col.array_nesting < 0 {
             return Err(anyhow!(
-                "Column '{}': precision and scale must be non-negative",
+                "Column '{}': precision, scale, and array_nesting must be non-negative",
                 col.name
             ));
         }
-        let dt = ffi_data_type_to_core(col.data_type, col.precision as u32, col.scale as u32)?;
+        let dt = ffi_column_to_core_data_type(col)?;
         schema_builder = schema_builder.column(&col.name, dt);
         if !col.comment.is_empty() {
             schema_builder = schema_builder.with_comment(&col.comment);
@@ -153,29 +269,7 @@ pub fn ffi_descriptor_to_core(
 
 pub fn core_table_info_to_ffi(info: &fcore::metadata::TableInfo) -> ffi::FfiTableInfo {
     let schema = info.get_schema();
-    let columns: Vec<ffi::FfiColumn> = schema
-        .columns()
-        .iter()
-        .map(|col| {
-            let (precision, scale) = match col.data_type() {
-                fcore::metadata::DataType::Decimal(dt) => {
-                    (dt.precision() as i32, dt.scale() as i32)
-                }
-                fcore::metadata::DataType::Timestamp(dt) => (dt.precision() as i32, 0),
-                fcore::metadata::DataType::TimestampLTz(dt) => (dt.precision() as i32, 0),
-                fcore::metadata::DataType::Char(dt) => (dt.length() as i32, 0),
-                fcore::metadata::DataType::Binary(dt) => (dt.length() as i32, 0),
-                _ => (0, 0),
-            };
-            ffi::FfiColumn {
-                name: col.name().to_string(),
-                data_type: core_data_type_to_ffi(col.data_type()),
-                comment: col.comment().unwrap_or("").to_string(),
-                precision,
-                scale,
-            }
-        })
-        .collect();
+    let columns: Vec<ffi::FfiColumn> = schema.columns().iter().map(core_column_to_ffi).collect();
 
     let primary_keys: Vec<String> = schema
         .primary_key()
@@ -248,6 +342,21 @@ pub fn empty_table_info() -> ffi::FfiTableInfo {
             columns: vec![],
             primary_keys: vec![],
         },
+    }
+}
+
+/// Convert element type tag + precision/scale to core DataType.
+/// Used by ArrayWriterInner construction from C++.
+pub fn element_type_from_ffi(
+    leaf_dt: i32,
+    precision: u32,
+    scale: u32,
+    array_nesting: u32,
+) -> Result<fcore::metadata::DataType> {
+    if array_nesting == 0 {
+        ffi_data_type_to_core(leaf_dt, precision, scale, 0, 0, 0, 0)
+    } else {
+        build_array_type_from_leaf(leaf_dt, precision, scale, array_nesting)
     }
 }
 
@@ -351,8 +460,6 @@ pub fn resolve_row_types(
             Datum::Time(t) => Datum::Time(*t),
             Datum::TimestampNtz(ts) => Datum::TimestampNtz(*ts),
             Datum::TimestampLtz(ts) => Datum::TimestampLtz(*ts),
-            // TODO: C++ bindings need proper CXX wrapper types for FlussArray
-            // before C++ users can construct or inspect array values through FFI.
             Datum::Array(a) => Datum::Array(a.clone()),
         };
         out.set_field(idx, resolved);
@@ -411,8 +518,6 @@ pub fn compacted_row_to_owned(
             fcore::metadata::DataType::Binary(dt) => {
                 Datum::Blob(Cow::Owned(row.get_binary(i, dt.length())?.to_vec()))
             }
-            // TODO: C++ bindings need proper CXX wrapper types for FlussArray
-            // before C++ users can construct or inspect array values through FFI.
             fcore::metadata::DataType::Array(_) => Datum::Array(row.get_array(i)?),
             other => return Err(anyhow!("Unsupported data type for column {i}: {other:?}")),
         };

--- a/bindings/cpp/test/test_ffi_converter.cpp
+++ b/bindings/cpp/test/test_ffi_converter.cpp
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+#include "ffi_converter.hpp"
+
+namespace {
+
+fluss::ffi::FfiColumn MakeArrayColumn(int32_t nesting, int32_t element_type) {
+    fluss::ffi::FfiColumn col;
+    col.name = rust::String("bad_array");
+    col.data_type = static_cast<int32_t>(fluss::TypeId::Array);
+    col.comment = rust::String("");
+    col.precision = 0;
+    col.scale = 0;
+    col.array_nesting = nesting;
+    col.element_data_type = element_type;
+    col.element_precision = 0;
+    col.element_scale = 0;
+    return col;
+}
+
+}  // namespace
+
+TEST(FfiConverterTest, RejectsArrayWithoutElementType) {
+    auto col = MakeArrayColumn(1, 0);
+    EXPECT_THROW((void)fluss::utils::from_ffi_column(col), std::runtime_error);
+}
+
+TEST(FfiConverterTest, RejectsArrayWithArrayLeafType) {
+    auto col = MakeArrayColumn(2, static_cast<int32_t>(fluss::TypeId::Array));
+    EXPECT_THROW((void)fluss::utils::from_ffi_column(col), std::runtime_error);
+}
+
+TEST(FfiConverterTest, RejectsArrayWithUnknownLeafType) {
+    auto col = MakeArrayColumn(1, 999);
+    EXPECT_THROW((void)fluss::utils::from_ffi_column(col), std::runtime_error);
+}
+
+TEST(FfiConverterTest, SupportsLegacyOneLevelArrayMetadata) {
+    auto col = MakeArrayColumn(0, static_cast<int32_t>(fluss::TypeId::Int));
+    auto converted = fluss::utils::from_ffi_column(col);
+    EXPECT_EQ(converted.data_type.id(), fluss::TypeId::Array);
+    ASSERT_NE(converted.data_type.element_type(), nullptr);
+    EXPECT_EQ(converted.data_type.element_type()->id(), fluss::TypeId::Int);
+}

--- a/bindings/cpp/test/test_kv_table.cpp
+++ b/bindings/cpp/test/test_kv_table.cpp
@@ -197,7 +197,7 @@ TEST_F(KvTableTest, LookupWithNestedArrayArrayView) {
         fluss::ArrayWriter outer(2, fluss::DataType::Array(fluss::DataType::Int()));
         outer.SetArray(0, std::move(inner1));
         outer.SetArray(1, std::move(inner2));
-        row.SetArray("matrix", std::move(outer));
+        row.Set("matrix", std::move(outer));
 
         ASSERT_OK(writer.Upsert(row));
         ASSERT_OK(writer.Flush());
@@ -262,7 +262,7 @@ TEST_F(KvTableTest, LookupArrayValidationErrors) {
     fluss::ArrayWriter vals(2, fluss::DataType::Int());
     vals.SetInt32(0, 99);
     vals.SetNull(1);
-    row.SetArray("vals", std::move(vals));
+    row.Set("vals", std::move(vals));
     ASSERT_OK(writer.Upsert(row));
     ASSERT_OK(writer.Flush());
 

--- a/bindings/cpp/test/test_kv_table.cpp
+++ b/bindings/cpp/test/test_kv_table.cpp
@@ -234,6 +234,86 @@ TEST_F(KvTableTest, LookupWithNestedArrayArrayView) {
     ASSERT_OK(adm.DropTable(table_path, false));
 }
 
+TEST_F(KvTableTest, LookupArrayValidationErrors) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    fluss::TablePath table_path("fluss", "test_lookup_array_validation_errors_cpp");
+
+    auto schema = fluss::Schema::NewBuilder()
+                      .AddColumn("id", fluss::DataType::Int())
+                      .AddColumn("vals", fluss::DataType::Array(fluss::DataType::Int()))
+                      .SetPrimaryKeys({"id"})
+                      .Build();
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+    auto upsert = table.NewUpsert();
+    fluss::UpsertWriter writer;
+    ASSERT_OK(upsert.CreateWriter(writer));
+
+    auto row = table.NewRow();
+    row.Set("id", 1);
+    fluss::ArrayWriter vals(2, fluss::DataType::Int());
+    vals.SetInt32(0, 99);
+    vals.SetNull(1);
+    row.SetArray("vals", std::move(vals));
+    ASSERT_OK(writer.Upsert(row));
+    ASSERT_OK(writer.Flush());
+
+    fluss::Lookuper lookuper;
+    ASSERT_OK(table.NewLookup().CreateLookuper(lookuper));
+
+    auto key = table.NewRow();
+    key.Set("id", 1);
+    fluss::LookupResult result;
+    ASSERT_OK(lookuper.Lookup(key, result));
+    ASSERT_TRUE(result.Found());
+
+    bool wrong_type_threw = false;
+    try {
+        (void)result.GetArrayInt64("vals", 0);
+    } catch (const std::exception&) {
+        wrong_type_threw = true;
+    }
+    EXPECT_TRUE(wrong_type_threw);
+
+    bool null_typed_getter_threw = false;
+    try {
+        (void)result.GetArrayInt32("vals", 1);
+    } catch (const std::exception&) {
+        null_typed_getter_threw = true;
+    }
+    EXPECT_TRUE(null_typed_getter_threw);
+
+    auto view = result.GetArrayView("vals");
+    EXPECT_EQ(view.Size(), 2u);
+    EXPECT_TRUE(view.IsNull(1));
+
+    bool view_wrong_type_threw = false;
+    try {
+        (void)view.GetInt64(0);
+    } catch (const std::exception&) {
+        view_wrong_type_threw = true;
+    }
+    EXPECT_TRUE(view_wrong_type_threw);
+
+    bool view_null_typed_getter_threw = false;
+    try {
+        (void)view.GetInt32(1);
+    } catch (const std::exception&) {
+        view_null_typed_getter_threw = true;
+    }
+    EXPECT_TRUE(view_null_typed_getter_threw);
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
 TEST_F(KvTableTest, CompositePrimaryKeys) {
     auto& adm = admin();
     auto& conn = connection();

--- a/bindings/cpp/test/test_kv_table.cpp
+++ b/bindings/cpp/test/test_kv_table.cpp
@@ -155,6 +155,85 @@ TEST_F(KvTableTest, UpsertDeleteAndLookup) {
     ASSERT_OK(adm.DropTable(table_path, false));
 }
 
+TEST_F(KvTableTest, LookupWithNestedArrayArrayView) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    fluss::TablePath table_path("fluss", "test_lookup_nested_array_cpp");
+
+    auto schema = fluss::Schema::NewBuilder()
+                      .AddColumn("id", fluss::DataType::Int())
+                      .AddColumn("matrix",
+                                 fluss::DataType::Array(fluss::DataType::Array(fluss::DataType::Int())))
+                      .SetPrimaryKeys({"id"})
+                      .Build();
+
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+
+    auto upsert = table.NewUpsert();
+    fluss::UpsertWriter writer;
+    ASSERT_OK(upsert.CreateWriter(writer));
+
+    {
+        auto row = table.NewRow();
+        row.Set("id", 1);
+
+        fluss::ArrayWriter inner1(2, fluss::DataType::Int());
+        inner1.SetInt32(0, 11);
+        inner1.SetInt32(1, 12);
+
+        fluss::ArrayWriter inner2(2, fluss::DataType::Int());
+        inner2.SetInt32(0, 21);
+        inner2.SetInt32(1, 22);
+
+        fluss::ArrayWriter outer(2, fluss::DataType::Array(fluss::DataType::Int()));
+        outer.SetArray(0, std::move(inner1));
+        outer.SetArray(1, std::move(inner2));
+        row.SetArray("matrix", std::move(outer));
+
+        ASSERT_OK(writer.Upsert(row));
+        ASSERT_OK(writer.Flush());
+    }
+
+    fluss::Lookuper lookuper;
+    ASSERT_OK(table.NewLookup().CreateLookuper(lookuper));
+
+    auto key = table.NewRow();
+    key.Set("id", 1);
+
+    fluss::LookupResult result;
+    ASSERT_OK(lookuper.Lookup(key, result));
+    ASSERT_TRUE(result.Found());
+    EXPECT_EQ(result.GetArraySize("matrix"), 2u);
+    EXPECT_EQ(result.GetArrayElementType("matrix"), fluss::TypeId::Array);
+
+    auto outer = result.GetArrayView("matrix");
+    ASSERT_EQ(outer.Size(), 2u);
+    EXPECT_EQ(outer.ElementType(), fluss::TypeId::Array);
+
+    auto first = outer.GetArray(0);
+    ASSERT_EQ(first.Size(), 2u);
+    EXPECT_EQ(first.ElementType(), fluss::TypeId::Int);
+    EXPECT_EQ(first.GetInt32(0), 11);
+    EXPECT_EQ(first.GetInt32(1), 12);
+
+    auto second = outer.GetArray(1);
+    ASSERT_EQ(second.Size(), 2u);
+    EXPECT_EQ(second.ElementType(), fluss::TypeId::Int);
+    EXPECT_EQ(second.GetInt32(0), 21);
+    EXPECT_EQ(second.GetInt32(1), 22);
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
 TEST_F(KvTableTest, CompositePrimaryKeys) {
     auto& adm = admin();
     auto& conn = connection();

--- a/bindings/cpp/test/test_log_table.cpp
+++ b/bindings/cpp/test/test_log_table.cpp
@@ -829,3 +829,393 @@ TEST_F(LogTableTest, PartitionedTableAppendScan) {
 
     ASSERT_OK(adm.DropTable(table_path, false));
 }
+
+// ============================================================================
+// Array data type tests
+// ============================================================================
+
+TEST_F(LogTableTest, AppendAndScanWithArray) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    fluss::TablePath table_path("fluss", "test_append_scan_with_array_cpp");
+
+    auto schema = fluss::Schema::NewBuilder()
+                      .AddColumn("id", fluss::DataType::Int())
+                      .AddColumn("tags", fluss::DataType::Array(fluss::DataType::String()))
+                      .AddColumn("scores", fluss::DataType::Array(fluss::DataType::Int()))
+                      .Build();
+
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetBucketCount(1)
+                                .SetBucketKeys({"id"})
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+
+    auto info = table.GetTableInfo();
+    ASSERT_GE(info.schema.columns.size(), 2u);
+    const auto& matrix_type = info.schema.columns[1].data_type;
+    ASSERT_EQ(matrix_type.id(), fluss::TypeId::Array);
+    ASSERT_NE(matrix_type.element_type(), nullptr);
+    ASSERT_EQ(matrix_type.element_type()->id(), fluss::TypeId::Array);
+    ASSERT_NE(matrix_type.element_type()->element_type(), nullptr);
+    ASSERT_EQ(matrix_type.element_type()->element_type()->id(), fluss::TypeId::Int);
+
+    auto append_writer = table.NewAppend().CreateWriter();
+
+    {
+        auto row = table.NewRow();
+        row.Set("id", 1);
+
+        fluss::ArrayWriter tags(2, fluss::DataType::String());
+        tags.SetString(0, "hello");
+        tags.SetString(1, "world");
+        row.SetArray(1, std::move(tags));
+
+        fluss::ArrayWriter scores(3, fluss::DataType::Int());
+        scores.SetInt32(0, 10);
+        scores.SetInt32(1, 20);
+        scores.SetInt32(2, 30);
+        row.SetArray(2, std::move(scores));
+
+        ASSERT_OK(append_writer.AppendRow(row));
+    }
+    {
+        auto row = table.NewRow();
+        row.Set("id", 2);
+
+        fluss::ArrayWriter tags(1, fluss::DataType::String());
+        tags.SetNull(0);
+        row.SetArray(1, std::move(tags));
+
+        fluss::ArrayWriter scores(0, fluss::DataType::Int());
+        row.SetArray(2, std::move(scores));
+
+        ASSERT_OK(append_writer.AppendRow(row));
+    }
+
+    ASSERT_OK(append_writer.Flush());
+
+    auto scan = table.NewScan();
+    fluss::LogScanner scanner;
+    ASSERT_OK(scan.CreateLogScanner(scanner));
+    ASSERT_OK(scanner.Subscribe(0, 0));
+
+    struct Record {
+        int32_t id;
+        size_t tag_count;
+        std::vector<std::string> tags;
+        size_t score_count;
+        std::vector<int32_t> scores;
+    };
+
+    std::vector<Record> collected;
+    auto extract = [](const fluss::RowView& rv) {
+        Record rec;
+        rec.id = rv.GetInt32(0);
+
+        rec.tag_count = rv.GetArraySize(1);
+        for (size_t i = 0; i < rec.tag_count; ++i) {
+            if (rv.IsArrayElementNull(1, i)) {
+                rec.tags.push_back("<null>");
+            } else {
+                rec.tags.push_back(rv.GetArrayString(1, i));
+            }
+        }
+
+        rec.score_count = rv.GetArraySize(2);
+        for (size_t i = 0; i < rec.score_count; ++i) {
+            rec.scores.push_back(rv.GetArrayInt32(2, i));
+        }
+
+        return rec;
+    };
+
+    fluss_test::PollRecords(scanner, 2, extract, collected);
+
+    ASSERT_EQ(collected.size(), 2u);
+
+    std::sort(collected.begin(), collected.end(),
+              [](const Record& a, const Record& b) { return a.id < b.id; });
+
+    EXPECT_EQ(collected[0].id, 1);
+    ASSERT_EQ(collected[0].tag_count, 2u);
+    EXPECT_EQ(collected[0].tags[0], "hello");
+    EXPECT_EQ(collected[0].tags[1], "world");
+    ASSERT_EQ(collected[0].score_count, 3u);
+    EXPECT_EQ(collected[0].scores[0], 10);
+    EXPECT_EQ(collected[0].scores[1], 20);
+    EXPECT_EQ(collected[0].scores[2], 30);
+
+    EXPECT_EQ(collected[1].id, 2);
+    ASSERT_EQ(collected[1].tag_count, 1u);
+    EXPECT_EQ(collected[1].tags[0], "<null>");
+    ASSERT_EQ(collected[1].score_count, 0u);
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
+TEST_F(LogTableTest, AppendAndScanWithNestedArray) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    fluss::TablePath table_path("fluss", "test_append_scan_nested_array_cpp");
+
+    auto schema =
+        fluss::Schema::NewBuilder()
+            .AddColumn("id", fluss::DataType::Int())
+            .AddColumn("matrix",
+                        fluss::DataType::Array(fluss::DataType::Array(fluss::DataType::Int())))
+            .Build();
+
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetBucketCount(1)
+                                .SetBucketKeys({"id"})
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+
+    auto append_writer = table.NewAppend().CreateWriter();
+
+    {
+        auto row = table.NewRow();
+        row.Set("id", 1);
+
+        fluss::ArrayWriter inner1(2, fluss::DataType::Int());
+        inner1.SetInt32(0, 1);
+        inner1.SetInt32(1, 2);
+
+        fluss::ArrayWriter inner2(2, fluss::DataType::Int());
+        inner2.SetInt32(0, 3);
+        inner2.SetInt32(1, 4);
+
+        fluss::ArrayWriter outer(2, fluss::DataType::Array(fluss::DataType::Int()));
+        outer.SetArray(0, std::move(inner1));
+        outer.SetArray(1, std::move(inner2));
+
+        row.SetArray(1, std::move(outer));
+        ASSERT_OK(append_writer.AppendRow(row));
+    }
+
+    ASSERT_OK(append_writer.Flush());
+
+    auto scan = table.NewScan();
+    fluss::LogScanner scanner;
+    ASSERT_OK(scan.CreateLogScanner(scanner));
+    ASSERT_OK(scanner.Subscribe(0, 0));
+
+    struct Record {
+        int32_t id;
+        size_t outer_count;
+        fluss::TypeId element_type;
+        std::vector<std::vector<int32_t>> values;
+    };
+
+    std::vector<Record> collected;
+    auto extract = [](const fluss::RowView& rv) {
+        Record rec;
+        rec.id = rv.GetInt32(0);
+        rec.outer_count = rv.GetArraySize(1);
+        rec.element_type = rv.GetArrayElementType(1);
+        auto outer = rv.GetArrayView(1);
+        rec.values.reserve(outer.Size());
+        for (size_t i = 0; i < outer.Size(); ++i) {
+            auto inner = outer.GetArray(i);
+            std::vector<int32_t> row;
+            row.reserve(inner.Size());
+            for (size_t j = 0; j < inner.Size(); ++j) {
+                row.push_back(inner.GetInt32(j));
+            }
+            rec.values.push_back(std::move(row));
+        }
+        return rec;
+    };
+
+    fluss_test::PollRecords(scanner, 1, extract, collected);
+    ASSERT_EQ(collected.size(), 1u);
+    EXPECT_EQ(collected[0].id, 1);
+    EXPECT_EQ(collected[0].outer_count, 2u);
+    EXPECT_EQ(collected[0].element_type, fluss::TypeId::Array);
+    ASSERT_EQ(collected[0].values.size(), 2u);
+    EXPECT_EQ(collected[0].values[0], (std::vector<int32_t>{1, 2}));
+    EXPECT_EQ(collected[0].values[1], (std::vector<int32_t>{3, 4}));
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
+TEST_F(LogTableTest, AppendAndScanWithArrayRichTypes) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    fluss::TablePath table_path("fluss", "test_append_scan_array_rich_types_cpp");
+
+    auto schema =
+        fluss::Schema::NewBuilder()
+            .AddColumn("id", fluss::DataType::Int())
+            .AddColumn("arr_bytes", fluss::DataType::Array(fluss::DataType::Bytes()))
+            .AddColumn("arr_date", fluss::DataType::Array(fluss::DataType::Date()))
+            .AddColumn("arr_time", fluss::DataType::Array(fluss::DataType::Time()))
+            .AddColumn("arr_ts", fluss::DataType::Array(fluss::DataType::Timestamp(6)))
+            .AddColumn("arr_decimal", fluss::DataType::Array(fluss::DataType::Decimal(10, 2)))
+            .Build();
+
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetBucketCount(1)
+                                .SetBucketKeys({"id"})
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+    auto append_writer = table.NewAppend().CreateWriter();
+
+    {
+        auto row = table.NewRow();
+        row.Set("id", 1);
+
+        fluss::ArrayWriter arr_bytes(2, fluss::DataType::Bytes());
+        arr_bytes.SetBytes(0, std::vector<uint8_t>{0x10, 0x20, 0x30});
+        arr_bytes.SetNull(1);
+        row.SetArray(1, std::move(arr_bytes));
+
+        fluss::ArrayWriter arr_date(2, fluss::DataType::Date());
+        auto d0 = fluss::Date::FromDays(20000);
+        arr_date.SetDate(0, d0);
+        arr_date.SetNull(1);
+        row.SetArray(2, std::move(arr_date));
+
+        fluss::ArrayWriter arr_time(1, fluss::DataType::Time());
+        auto t0 = fluss::Time::FromMillis(3600123);
+        arr_time.SetTime(0, t0);
+        row.SetArray(3, std::move(arr_time));
+
+        fluss::ArrayWriter arr_ts(1, fluss::DataType::Timestamp(6));
+        auto ts0 = fluss::Timestamp::FromMillisNanos(1769163227123, 456000);
+        arr_ts.SetTimestampNtz(0, ts0);
+        row.SetArray(4, std::move(arr_ts));
+
+        fluss::ArrayWriter arr_decimal(2, fluss::DataType::Decimal(10, 2));
+        arr_decimal.SetDecimal(0, "123.45");
+        arr_decimal.SetNull(1);
+        row.SetArray(5, std::move(arr_decimal));
+
+        ASSERT_OK(append_writer.AppendRow(row));
+    }
+
+    ASSERT_OK(append_writer.Flush());
+
+    auto scan = table.NewScan();
+    fluss::LogScanner scanner;
+    ASSERT_OK(scan.CreateLogScanner(scanner));
+    ASSERT_OK(scanner.Subscribe(0, 0));
+
+    fluss::ScanRecords records;
+    ASSERT_OK(scanner.Poll(10000, records));
+    ASSERT_EQ(records.Count(), 1u);
+
+    auto it = records.begin();
+    ASSERT_TRUE(it != records.end());
+    auto rec = *it;
+    const auto& rv = rec.row;
+
+    EXPECT_EQ(rv.GetArraySize(1), 2u);
+    auto bytes0 = rv.GetArrayBytes(1, 0);
+    ASSERT_EQ(bytes0.size(), 3u);
+    EXPECT_EQ(bytes0[0], 0x10);
+    EXPECT_EQ(bytes0[1], 0x20);
+    EXPECT_EQ(bytes0[2], 0x30);
+    EXPECT_TRUE(rv.IsArrayElementNull(1, 1));
+
+    EXPECT_EQ(rv.GetArraySize(2), 2u);
+    EXPECT_EQ(rv.GetArrayDate(2, 0).days_since_epoch, fluss::Date::FromDays(20000).days_since_epoch);
+    EXPECT_TRUE(rv.IsArrayElementNull(2, 1));
+
+    EXPECT_EQ(rv.GetArraySize(3), 1u);
+    EXPECT_EQ(rv.GetArrayTime(3, 0).millis_since_midnight, fluss::Time::FromMillis(3600123).millis_since_midnight);
+
+    EXPECT_EQ(rv.GetArraySize(4), 1u);
+    auto ts = rv.GetArrayTimestamp(4, 0);
+    EXPECT_EQ(ts.epoch_millis, 1769163227123);
+    EXPECT_EQ(ts.nano_of_millisecond, 456000);
+
+    EXPECT_EQ(rv.GetArraySize(5), 2u);
+    EXPECT_EQ(rv.GetArrayDecimalString(5, 0), "123.45");
+    EXPECT_TRUE(rv.IsArrayElementNull(5, 1));
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
+TEST_F(LogTableTest, ArrayApiValidationErrors) {
+    // Type mismatch setter should fail through FFI Result propagation.
+    {
+        fluss::ArrayWriter bool_array(1, fluss::DataType::Boolean());
+        bool threw = false;
+        try {
+            bool_array.SetInt32(0, 42);
+        } catch (const std::exception&) {
+            threw = true;
+        }
+        EXPECT_TRUE(threw);
+    }
+
+    auto& adm = admin();
+    auto& conn = connection();
+    fluss::TablePath table_path("fluss", "test_array_api_validation_errors_cpp");
+
+    auto schema = fluss::Schema::NewBuilder()
+                      .AddColumn("id", fluss::DataType::Int())
+                      .AddColumn("vals", fluss::DataType::Array(fluss::DataType::Int()))
+                      .Build();
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetBucketCount(1)
+                                .SetBucketKeys({"id"})
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+    auto append_writer = table.NewAppend().CreateWriter();
+    auto row = table.NewRow();
+    row.Set("id", 1);
+    fluss::ArrayWriter vals(1, fluss::DataType::Int());
+    vals.SetInt32(0, 7);
+    row.SetArray(1, std::move(vals));
+    ASSERT_OK(append_writer.AppendRow(row));
+    ASSERT_OK(append_writer.Flush());
+
+    auto scan = table.NewScan();
+    fluss::LogScanner scanner;
+    ASSERT_OK(scan.CreateLogScanner(scanner));
+    ASSERT_OK(scanner.Subscribe(0, 0));
+    fluss::ScanRecords records;
+    ASSERT_OK(scanner.Poll(10000, records));
+    ASSERT_EQ(records.Count(), 1u);
+    auto it = records.begin();
+    ASSERT_TRUE(it != records.end());
+    auto rec = *it;
+
+    bool oob_threw = false;
+    try {
+        (void)rec.row.GetArrayInt32(1, 5);
+    } catch (const std::exception&) {
+        oob_threw = true;
+    }
+    EXPECT_TRUE(oob_threw);
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}

--- a/bindings/cpp/test/test_log_table.cpp
+++ b/bindings/cpp/test/test_log_table.cpp
@@ -861,13 +861,15 @@ TEST_F(LogTableTest, AppendAndScanWithArray) {
     ASSERT_OK(conn.GetTable(table_path, table));
 
     auto info = table.GetTableInfo();
-    ASSERT_GE(info.schema.columns.size(), 2u);
-    const auto& matrix_type = info.schema.columns[1].data_type;
-    ASSERT_EQ(matrix_type.id(), fluss::TypeId::Array);
-    ASSERT_NE(matrix_type.element_type(), nullptr);
-    ASSERT_EQ(matrix_type.element_type()->id(), fluss::TypeId::Array);
-    ASSERT_NE(matrix_type.element_type()->element_type(), nullptr);
-    ASSERT_EQ(matrix_type.element_type()->element_type()->id(), fluss::TypeId::Int);
+    ASSERT_GE(info.schema.columns.size(), 3u);
+    const auto& tags_type = info.schema.columns[1].data_type;
+    ASSERT_EQ(tags_type.id(), fluss::TypeId::Array);
+    ASSERT_NE(tags_type.element_type(), nullptr);
+    ASSERT_EQ(tags_type.element_type()->id(), fluss::TypeId::String);
+    const auto& scores_type = info.schema.columns[2].data_type;
+    ASSERT_EQ(scores_type.id(), fluss::TypeId::Array);
+    ASSERT_NE(scores_type.element_type(), nullptr);
+    ASSERT_EQ(scores_type.element_type()->id(), fluss::TypeId::Int);
 
     fluss::AppendWriter append_writer;
     ASSERT_OK(table.NewAppend().CreateWriter(append_writer));
@@ -1105,7 +1107,7 @@ TEST_F(LogTableTest, AppendAndScanWithArrayRichTypes) {
         row.SetArray(2, std::move(arr_date));
 
         fluss::ArrayWriter arr_time(1, fluss::DataType::Time());
-        auto t0 = fluss::Time::FromMillis(3600123);
+        auto t0 = fluss::Time::FromMillis(3600000);
         arr_time.SetTime(0, t0);
         row.SetArray(3, std::move(arr_time));
 
@@ -1151,7 +1153,7 @@ TEST_F(LogTableTest, AppendAndScanWithArrayRichTypes) {
     EXPECT_TRUE(rv.IsArrayElementNull(2, 1));
 
     EXPECT_EQ(rv.GetArraySize(3), 1u);
-    EXPECT_EQ(rv.GetArrayTime(3, 0).millis_since_midnight, fluss::Time::FromMillis(3600123).millis_since_midnight);
+    EXPECT_EQ(rv.GetArrayTime(3, 0).millis_since_midnight, fluss::Time::FromMillis(3600000).millis_since_midnight);
 
     EXPECT_EQ(rv.GetArraySize(4), 1u);
     auto ts = rv.GetArrayTimestamp(4, 0);
@@ -1307,8 +1309,8 @@ TEST_F(LogTableTest, AppendAndScanWithArrayEncodingEdgeCases) {
 
         // precision > 18 forces non-compact decimal encoding
         fluss::ArrayWriter arr_big_decimal(2, fluss::DataType::Decimal(22, 5));
-        arr_big_decimal.SetDecimal(0, "1234567890123456789.12345");
-        arr_big_decimal.SetDecimal(1, "-9999999999999999999.99999");
+        arr_big_decimal.SetDecimal(0, "12345678901234567.12345");
+        arr_big_decimal.SetDecimal(1, "-99999999999999999.99999");
         row.SetArray(2, std::move(arr_big_decimal));
 
         // precision > 3 forces non-compact timestamp (millis + nanos-of-millis)
@@ -1362,8 +1364,8 @@ TEST_F(LogTableTest, AppendAndScanWithArrayEncodingEdgeCases) {
 
     // Non-compact decimal (precision 22 > MAX_COMPACT_PRECISION 18)
     EXPECT_EQ(rv.GetArraySize(2), 2u);
-    EXPECT_EQ(rv.GetArrayDecimalString(2, 0), "1234567890123456789.12345");
-    EXPECT_EQ(rv.GetArrayDecimalString(2, 1), "-9999999999999999999.99999");
+    EXPECT_EQ(rv.GetArrayDecimalString(2, 0), "12345678901234567.12345");
+    EXPECT_EQ(rv.GetArrayDecimalString(2, 1), "-99999999999999999.99999");
 
     // Non-compact timestamp (precision 9 > MAX_COMPACT_TIMESTAMP_PRECISION 3)
     EXPECT_EQ(rv.GetArraySize(3), 1u);

--- a/bindings/cpp/test/test_log_table.cpp
+++ b/bindings/cpp/test/test_log_table.cpp
@@ -1192,8 +1192,9 @@ TEST_F(LogTableTest, ArrayApiValidationErrors) {
     auto append_writer = table.NewAppend().CreateWriter();
     auto row = table.NewRow();
     row.Set("id", 1);
-    fluss::ArrayWriter vals(1, fluss::DataType::Int());
+    fluss::ArrayWriter vals(2, fluss::DataType::Int());
     vals.SetInt32(0, 7);
+    vals.SetNull(1);
     row.SetArray(1, std::move(vals));
     ASSERT_OK(append_writer.AppendRow(row));
     ASSERT_OK(append_writer.Flush());
@@ -1216,6 +1217,42 @@ TEST_F(LogTableTest, ArrayApiValidationErrors) {
         oob_threw = true;
     }
     EXPECT_TRUE(oob_threw);
+
+    bool wrong_type_threw = false;
+    try {
+        (void)rec.row.GetArrayInt64(1, 0);
+    } catch (const std::exception&) {
+        wrong_type_threw = true;
+    }
+    EXPECT_TRUE(wrong_type_threw);
+
+    bool null_typed_getter_threw = false;
+    try {
+        (void)rec.row.GetArrayInt32(1, 1);
+    } catch (const std::exception&) {
+        null_typed_getter_threw = true;
+    }
+    EXPECT_TRUE(null_typed_getter_threw);
+
+    auto view = rec.row.GetArrayView(1);
+    EXPECT_EQ(view.Size(), 2u);
+    EXPECT_TRUE(view.IsNull(1));
+
+    bool view_wrong_type_threw = false;
+    try {
+        (void)view.GetInt64(0);
+    } catch (const std::exception&) {
+        view_wrong_type_threw = true;
+    }
+    EXPECT_TRUE(view_wrong_type_threw);
+
+    bool view_null_typed_getter_threw = false;
+    try {
+        (void)view.GetInt32(1);
+    } catch (const std::exception&) {
+        view_null_typed_getter_threw = true;
+    }
+    EXPECT_TRUE(view_null_typed_getter_threw);
 
     ASSERT_OK(adm.DropTable(table_path, false));
 }

--- a/bindings/cpp/test/test_log_table.cpp
+++ b/bindings/cpp/test/test_log_table.cpp
@@ -867,7 +867,8 @@ TEST_F(LogTableTest, AppendAndScanWithArray) {
     ASSERT_NE(matrix_type.element_type()->element_type(), nullptr);
     ASSERT_EQ(matrix_type.element_type()->element_type()->id(), fluss::TypeId::Int);
 
-    auto append_writer = table.NewAppend().CreateWriter();
+    fluss::AppendWriter append_writer;
+    ASSERT_OK(table.NewAppend().CreateWriter(append_writer));
 
     {
         auto row = table.NewRow();
@@ -884,7 +885,7 @@ TEST_F(LogTableTest, AppendAndScanWithArray) {
         scores.SetInt32(2, 30);
         row.SetArray(2, std::move(scores));
 
-        ASSERT_OK(append_writer.AppendRow(row));
+        ASSERT_OK(append_writer.Append(row));
     }
     {
         auto row = table.NewRow();
@@ -897,7 +898,7 @@ TEST_F(LogTableTest, AppendAndScanWithArray) {
         fluss::ArrayWriter scores(0, fluss::DataType::Int());
         row.SetArray(2, std::move(scores));
 
-        ASSERT_OK(append_writer.AppendRow(row));
+        ASSERT_OK(append_writer.Append(row));
     }
 
     ASSERT_OK(append_writer.Flush());
@@ -916,7 +917,8 @@ TEST_F(LogTableTest, AppendAndScanWithArray) {
     };
 
     std::vector<Record> collected;
-    auto extract = [](const fluss::RowView& rv) {
+    auto extract = [](const fluss::ScanRecord& scan_rec) {
+        const auto& rv = scan_rec.row;
         Record rec;
         rec.id = rv.GetInt32(0);
 
@@ -986,7 +988,8 @@ TEST_F(LogTableTest, AppendAndScanWithNestedArray) {
     fluss::Table table;
     ASSERT_OK(conn.GetTable(table_path, table));
 
-    auto append_writer = table.NewAppend().CreateWriter();
+    fluss::AppendWriter append_writer;
+    ASSERT_OK(table.NewAppend().CreateWriter(append_writer));
 
     {
         auto row = table.NewRow();
@@ -1005,7 +1008,7 @@ TEST_F(LogTableTest, AppendAndScanWithNestedArray) {
         outer.SetArray(1, std::move(inner2));
 
         row.SetArray(1, std::move(outer));
-        ASSERT_OK(append_writer.AppendRow(row));
+        ASSERT_OK(append_writer.Append(row));
     }
 
     ASSERT_OK(append_writer.Flush());
@@ -1023,7 +1026,8 @@ TEST_F(LogTableTest, AppendAndScanWithNestedArray) {
     };
 
     std::vector<Record> collected;
-    auto extract = [](const fluss::RowView& rv) {
+    auto extract = [](const fluss::ScanRecord& scan_rec) {
+        const auto& rv = scan_rec.row;
         Record rec;
         rec.id = rv.GetInt32(0);
         rec.outer_count = rv.GetArraySize(1);
@@ -1080,7 +1084,8 @@ TEST_F(LogTableTest, AppendAndScanWithArrayRichTypes) {
 
     fluss::Table table;
     ASSERT_OK(conn.GetTable(table_path, table));
-    auto append_writer = table.NewAppend().CreateWriter();
+    fluss::AppendWriter append_writer;
+    ASSERT_OK(table.NewAppend().CreateWriter(append_writer));
 
     {
         auto row = table.NewRow();
@@ -1112,7 +1117,7 @@ TEST_F(LogTableTest, AppendAndScanWithArrayRichTypes) {
         arr_decimal.SetNull(1);
         row.SetArray(5, std::move(arr_decimal));
 
-        ASSERT_OK(append_writer.AppendRow(row));
+        ASSERT_OK(append_writer.Append(row));
     }
 
     ASSERT_OK(append_writer.Flush());
@@ -1189,14 +1194,15 @@ TEST_F(LogTableTest, ArrayApiValidationErrors) {
 
     fluss::Table table;
     ASSERT_OK(conn.GetTable(table_path, table));
-    auto append_writer = table.NewAppend().CreateWriter();
+    fluss::AppendWriter append_writer;
+    ASSERT_OK(table.NewAppend().CreateWriter(append_writer));
     auto row = table.NewRow();
     row.Set("id", 1);
     fluss::ArrayWriter vals(2, fluss::DataType::Int());
     vals.SetInt32(0, 7);
     vals.SetNull(1);
     row.SetArray(1, std::move(vals));
-    ASSERT_OK(append_writer.AppendRow(row));
+    ASSERT_OK(append_writer.Append(row));
     ASSERT_OK(append_writer.Flush());
 
     auto scan = table.NewScan();

--- a/bindings/cpp/test/test_log_table.cpp
+++ b/bindings/cpp/test/test_log_table.cpp
@@ -22,6 +22,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
+#include <limits>
 #include <thread>
 #include <tuple>
 
@@ -1261,4 +1263,196 @@ TEST_F(LogTableTest, ArrayApiValidationErrors) {
     EXPECT_TRUE(view_null_typed_getter_threw);
 
     ASSERT_OK(adm.DropTable(table_path, false));
+}
+
+TEST_F(LogTableTest, AppendAndScanWithArrayEncodingEdgeCases) {
+    auto& adm = admin();
+    auto& conn = connection();
+
+    fluss::TablePath table_path("fluss", "test_array_encoding_edge_cases_cpp");
+
+    auto schema =
+        fluss::Schema::NewBuilder()
+            .AddColumn("id", fluss::DataType::Int())
+            .AddColumn("arr_long_str", fluss::DataType::Array(fluss::DataType::String()))
+            .AddColumn("arr_big_decimal", fluss::DataType::Array(fluss::DataType::Decimal(22, 5)))
+            .AddColumn("arr_ts_nano", fluss::DataType::Array(fluss::DataType::Timestamp(9)))
+            .AddColumn("arr_float", fluss::DataType::Array(fluss::DataType::Float()))
+            .AddColumn("arr_double", fluss::DataType::Array(fluss::DataType::Double()))
+            .AddColumn("arr_binary", fluss::DataType::Array(fluss::DataType::Binary(4)))
+            .Build();
+
+    auto table_descriptor = fluss::TableDescriptor::NewBuilder()
+                                .SetSchema(schema)
+                                .SetBucketCount(1)
+                                .SetBucketKeys({"id"})
+                                .SetProperty("table.replication.factor", "1")
+                                .Build();
+    fluss_test::CreateTable(adm, table_path, table_descriptor);
+
+    fluss::Table table;
+    ASSERT_OK(conn.GetTable(table_path, table));
+    fluss::AppendWriter append_writer;
+    ASSERT_OK(table.NewAppend().CreateWriter(append_writer));
+
+    {
+        auto row = table.NewRow();
+        row.Set("id", 1);
+
+        // >= 8 bytes forces the heap-pointer variable-length path (threshold: 7)
+        fluss::ArrayWriter arr_long_str(2, fluss::DataType::String());
+        arr_long_str.SetString(0, "abcdefgh");
+        arr_long_str.SetString(1, "this is a much longer string that definitely exceeds inline");
+        row.SetArray(1, std::move(arr_long_str));
+
+        // precision > 18 forces non-compact decimal encoding
+        fluss::ArrayWriter arr_big_decimal(2, fluss::DataType::Decimal(22, 5));
+        arr_big_decimal.SetDecimal(0, "1234567890123456789.12345");
+        arr_big_decimal.SetDecimal(1, "-9999999999999999999.99999");
+        row.SetArray(2, std::move(arr_big_decimal));
+
+        // precision > 3 forces non-compact timestamp (millis + nanos-of-millis)
+        fluss::ArrayWriter arr_ts_nano(1, fluss::DataType::Timestamp(9));
+        auto ts_nano = fluss::Timestamp::FromMillisNanos(1769163227123, 456789);
+        arr_ts_nano.SetTimestampNtz(0, ts_nano);
+        row.SetArray(3, std::move(arr_ts_nano));
+
+        // IEEE 754 special values: NaN, +Infinity, -Infinity
+        fluss::ArrayWriter arr_float(3, fluss::DataType::Float());
+        arr_float.SetFloat32(0, std::numeric_limits<float>::quiet_NaN());
+        arr_float.SetFloat32(1, std::numeric_limits<float>::infinity());
+        arr_float.SetFloat32(2, -std::numeric_limits<float>::infinity());
+        row.SetArray(4, std::move(arr_float));
+
+        fluss::ArrayWriter arr_double(3, fluss::DataType::Double());
+        arr_double.SetFloat64(0, std::numeric_limits<double>::quiet_NaN());
+        arr_double.SetFloat64(1, std::numeric_limits<double>::infinity());
+        arr_double.SetFloat64(2, -std::numeric_limits<double>::infinity());
+        row.SetArray(5, std::move(arr_double));
+
+        // Fixed-length binary
+        fluss::ArrayWriter arr_binary(2, fluss::DataType::Binary(4));
+        arr_binary.SetBytes(0, std::vector<uint8_t>{0xDE, 0xAD, 0xBE, 0xEF});
+        arr_binary.SetNull(1);
+        row.SetArray(6, std::move(arr_binary));
+
+        ASSERT_OK(append_writer.Append(row));
+    }
+
+    ASSERT_OK(append_writer.Flush());
+
+    auto scan = table.NewScan();
+    fluss::LogScanner scanner;
+    ASSERT_OK(scan.CreateLogScanner(scanner));
+    ASSERT_OK(scanner.Subscribe(0, 0));
+
+    fluss::ScanRecords records;
+    ASSERT_OK(scanner.Poll(10000, records));
+    ASSERT_EQ(records.Count(), 1u);
+
+    auto it = records.begin();
+    ASSERT_TRUE(it != records.end());
+    auto rec = *it;
+    const auto& rv = rec.row;
+
+    // Long strings: heap-encoded variable-length round-trip
+    EXPECT_EQ(rv.GetArraySize(1), 2u);
+    EXPECT_EQ(rv.GetArrayString(1, 0), "abcdefgh");
+    EXPECT_EQ(rv.GetArrayString(1, 1), "this is a much longer string that definitely exceeds inline");
+
+    // Non-compact decimal (precision 22 > MAX_COMPACT_PRECISION 18)
+    EXPECT_EQ(rv.GetArraySize(2), 2u);
+    EXPECT_EQ(rv.GetArrayDecimalString(2, 0), "1234567890123456789.12345");
+    EXPECT_EQ(rv.GetArrayDecimalString(2, 1), "-9999999999999999999.99999");
+
+    // Non-compact timestamp (precision 9 > MAX_COMPACT_TIMESTAMP_PRECISION 3)
+    EXPECT_EQ(rv.GetArraySize(3), 1u);
+    auto ts = rv.GetArrayTimestamp(3, 0);
+    EXPECT_EQ(ts.epoch_millis, 1769163227123);
+    EXPECT_EQ(ts.nano_of_millisecond, 456789);
+
+    // Float NaN / Infinity round-trip
+    EXPECT_EQ(rv.GetArraySize(4), 3u);
+    EXPECT_TRUE(std::isnan(rv.GetArrayFloat32(4, 0)));
+    EXPECT_TRUE(std::isinf(rv.GetArrayFloat32(4, 1)));
+    EXPECT_GT(rv.GetArrayFloat32(4, 1), 0.0f);
+    EXPECT_TRUE(std::isinf(rv.GetArrayFloat32(4, 2)));
+    EXPECT_LT(rv.GetArrayFloat32(4, 2), 0.0f);
+
+    // Double NaN / Infinity round-trip
+    EXPECT_EQ(rv.GetArraySize(5), 3u);
+    EXPECT_TRUE(std::isnan(rv.GetArrayFloat64(5, 0)));
+    EXPECT_TRUE(std::isinf(rv.GetArrayFloat64(5, 1)));
+    EXPECT_GT(rv.GetArrayFloat64(5, 1), 0.0);
+    EXPECT_TRUE(std::isinf(rv.GetArrayFloat64(5, 2)));
+    EXPECT_LT(rv.GetArrayFloat64(5, 2), 0.0);
+
+    // Fixed-length binary round-trip
+    EXPECT_EQ(rv.GetArraySize(6), 2u);
+    auto bin = rv.GetArrayBytes(6, 0);
+    ASSERT_EQ(bin.size(), 4u);
+    EXPECT_EQ(bin[0], 0xDE);
+    EXPECT_EQ(bin[1], 0xAD);
+    EXPECT_EQ(bin[2], 0xBE);
+    EXPECT_EQ(bin[3], 0xEF);
+    EXPECT_TRUE(rv.IsArrayElementNull(6, 1));
+
+    ASSERT_OK(adm.DropTable(table_path, false));
+}
+
+TEST_F(LogTableTest, ArrayWriterOverflowDetection) {
+    // SetInt32 on TINYINT array must throw when value overflows i8 range (-128..127)
+    {
+        fluss::ArrayWriter tinyint_arr(1, fluss::DataType::TinyInt());
+        EXPECT_EQ(tinyint_arr.Size(), 1u);
+        bool threw = false;
+        try {
+            tinyint_arr.SetInt32(0, 1000);
+        } catch (const std::exception& e) {
+            threw = true;
+            std::string msg(e.what());
+            EXPECT_NE(msg.find("TINYINT"), std::string::npos);
+        }
+        EXPECT_TRUE(threw);
+    }
+
+    // SetInt32 on SMALLINT array must throw when value overflows i16 range (-32768..32767)
+    {
+        fluss::ArrayWriter smallint_arr(1, fluss::DataType::SmallInt());
+        bool threw = false;
+        try {
+            smallint_arr.SetInt32(0, 40000);
+        } catch (const std::exception& e) {
+            threw = true;
+            std::string msg(e.what());
+            EXPECT_NE(msg.find("SMALLINT"), std::string::npos);
+        }
+        EXPECT_TRUE(threw);
+    }
+
+    // Negative overflow: -200 doesn't fit TINYINT
+    {
+        fluss::ArrayWriter tinyint_arr(1, fluss::DataType::TinyInt());
+        bool threw = false;
+        try {
+            tinyint_arr.SetInt32(0, -200);
+        } catch (const std::exception&) {
+            threw = true;
+        }
+        EXPECT_TRUE(threw);
+    }
+
+    // Values within range must succeed
+    {
+        fluss::ArrayWriter tinyint_arr(1, fluss::DataType::TinyInt());
+        EXPECT_NO_THROW(tinyint_arr.SetInt32(0, 127));
+    }
+    {
+        fluss::ArrayWriter tinyint_arr(1, fluss::DataType::TinyInt());
+        EXPECT_NO_THROW(tinyint_arr.SetInt32(0, -128));
+    }
+    {
+        fluss::ArrayWriter smallint_arr(1, fluss::DataType::SmallInt());
+        EXPECT_NO_THROW(smallint_arr.SetInt32(0, 32767));
+    }
 }

--- a/website/docs/user-guide/cpp/api-reference.md
+++ b/website/docs/user-guide/cpp/api-reference.md
@@ -212,6 +212,7 @@ Complete API reference for the Fluss C++ client.
 | `SetTimestampNtz(size_t idx, const Timestamp& value)`     | Set timestamp without timezone |
 | `SetTimestampLtz(size_t idx, const Timestamp& value)`     | Set timestamp with timezone    |
 | `SetDecimal(size_t idx, const std::string& value)`        | Set decimal from string        |
+| `SetArray(size_t idx, ArrayWriter&& writer)`              | Set array value (consumes the writer) |
 
 ### Name-Based Setters
 
@@ -257,6 +258,28 @@ Read-only row view for scan results. Provides zero-copy access to string and byt
 | `GetTimestamp(size_t idx) -> Timestamp`                    | Get timestamp at index         |
 | `IsDecimal(size_t idx) -> bool`                            | Check if field is a decimal type|
 | `GetDecimalString(size_t idx) -> std::string`              | Get decimal as string at index |
+
+### Array Getters (Index-Based)
+
+| Method                                                             |  Description                              |
+|--------------------------------------------------------------------|-------------------------------------------|
+| `GetArraySize(size_t idx) -> size_t`                               | Get element count of array at index       |
+| `GetArrayElementType(size_t idx) -> TypeId`                        | Get element type of array at index        |
+| `IsArrayElementNull(size_t idx, size_t element) -> bool`           | Check if array element is null            |
+| `GetArrayBool(size_t idx, size_t element) -> bool`                 | Get boolean array element                 |
+| `GetArrayInt32(size_t idx, size_t element) -> int32_t`             | Get 32-bit integer array element          |
+| `GetArrayInt64(size_t idx, size_t element) -> int64_t`             | Get 64-bit integer array element          |
+| `GetArrayFloat32(size_t idx, size_t element) -> float`             | Get 32-bit float array element            |
+| `GetArrayFloat64(size_t idx, size_t element) -> double`            | Get 64-bit float array element            |
+| `GetArrayString(size_t idx, size_t element) -> std::string`        | Get string array element                  |
+| `GetArrayBytes(size_t idx, size_t element) -> std::vector<uint8_t>`| Get binary array element                  |
+| `GetArrayDate(size_t idx, size_t element) -> Date`                 | Get date array element                    |
+| `GetArrayTime(size_t idx, size_t element) -> Time`                 | Get time array element                    |
+| `GetArrayTimestamp(size_t idx, size_t element) -> Timestamp`       | Get timestamp array element               |
+| `GetArrayDecimalString(size_t idx, size_t element) -> std::string` | Get decimal array element as string       |
+| `GetArrayView(size_t idx) -> ArrayView`                            | Get owning ArrayView for nested access    |
+
+All array getters are also available by column name (e.g., `GetArraySize("col")`, `GetArrayView("col")`).
 
 ### Name-Based Getters
 
@@ -364,6 +387,10 @@ Read-only result for lookup operations. Provides zero-copy access to field value
 | `IsDecimal(size_t idx) -> bool`                            | Check if field is a decimal type|
 | `GetDecimalString(size_t idx) -> std::string`              | Get decimal as string at index |
 
+### Array Getters (Index-Based)
+
+Same array getters as [`RowView`](#array-getters-index-based) — `GetArraySize`, `GetArrayInt32`, `GetArrayView`, etc. Also available by column name.
+
 ### Name-Based Getters
 
 | Method                                                  |  Description                       |
@@ -456,14 +483,61 @@ Read-only result for lookup operations. Provides zero-copy access to field value
 | `DataType::Timestamp(int precision)`          | Timestamp without timezone         |
 | `DataType::TimestampLtz(int precision)`       | Timestamp with timezone            |
 | `DataType::Decimal(int precision, int scale)` | Decimal with precision and scale   |
+| `DataType::Array(DataType element)`           | Array of the given element type    |
 
 ### Accessors
 
-| Method               |  Description                                |
-|----------------------|---------------------------------------------|
-| `id() -> TypeId`     | Get the type ID                             |
-| `precision() -> int` | Get precision (for Decimal/Timestamp types) |
-| `scale() -> int`     | Get scale (for Decimal type)                |
+| Method                              |  Description                                |
+|-------------------------------------|---------------------------------------------|
+| `id() -> TypeId`                    | Get the type ID                             |
+| `precision() -> int`               | Get precision (for Decimal/Timestamp types) |
+| `scale() -> int`                   | Get scale (for Decimal type)                |
+| `element_type() -> const DataType*` | Get element type (for Array type, nullptr otherwise) |
+
+## `ArrayWriter`
+
+Write-only builder for array column values. Constructed with a fixed size and element type, then populated element-by-element. Move-only — consumed by `GenericRow::SetArray()` or `ArrayWriter::SetArray()` for nested arrays.
+
+| Method                                                    |  Description                              |
+|-----------------------------------------------------------|-------------------------------------------|
+| `ArrayWriter(size_t size, DataType element_type)`         | Create an array writer                    |
+| `SetNull(size_t idx)`                                     | Set element to null                       |
+| `SetBool(size_t idx, bool value)`                         | Set boolean element                       |
+| `SetInt32(size_t idx, int32_t value)`                     | Set 32-bit integer element                |
+| `SetInt64(size_t idx, int64_t value)`                     | Set 64-bit integer element                |
+| `SetFloat32(size_t idx, float value)`                     | Set 32-bit float element                  |
+| `SetFloat64(size_t idx, double value)`                    | Set 64-bit float element                  |
+| `SetString(size_t idx, const std::string& value)`         | Set string element                        |
+| `SetBytes(size_t idx, const std::vector<uint8_t>& value)` | Set binary element                        |
+| `SetDate(size_t idx, const Date& value)`                  | Set date element                          |
+| `SetTime(size_t idx, const Time& value)`                  | Set time element                          |
+| `SetTimestampNtz(size_t idx, const Timestamp& value)`     | Set timestamp without timezone element    |
+| `SetTimestampLtz(size_t idx, const Timestamp& value)`     | Set timestamp with timezone element       |
+| `SetDecimal(size_t idx, const std::string& value)`        | Set decimal element from string           |
+| `SetArray(size_t idx, ArrayWriter&& nested)`              | Set nested array element (consumes nested)|
+
+## `ArrayView`
+
+Read-only view over an array column value. Obtained from `RowView::GetArrayView()` or `LookupResult::GetArrayView()`, and recursively from `ArrayView::GetArray()` for nested `ARRAY<ARRAY<...>>` columns. Move-only.
+
+| Method                                                  |  Description                              |
+|---------------------------------------------------------|-------------------------------------------|
+| `Size() -> size_t`                                      | Get element count                         |
+| `ElementType() -> TypeId`                               | Get element type                          |
+| `IsNull(size_t element) -> bool`                        | Check if element is null                  |
+| `GetBool(size_t element) -> bool`                       | Get boolean element                       |
+| `GetInt32(size_t element) -> int32_t`                   | Get 32-bit integer element                |
+| `GetInt64(size_t element) -> int64_t`                   | Get 64-bit integer element                |
+| `GetFloat32(size_t element) -> float`                   | Get 32-bit float element                  |
+| `GetFloat64(size_t element) -> double`                  | Get 64-bit float element                  |
+| `GetString(size_t element) -> std::string`              | Get string element                        |
+| `GetBytes(size_t element) -> std::vector<uint8_t>`      | Get binary element                        |
+| `GetDate(size_t element) -> Date`                       | Get date element                          |
+| `GetTime(size_t element) -> Time`                       | Get time element                          |
+| `GetTimestamp(size_t element) -> Timestamp`              | Get timestamp element                     |
+| `GetTimestampLtz(size_t element) -> Timestamp`          | Get timestamp with timezone element       |
+| `GetDecimalString(size_t element) -> std::string`       | Get decimal element as string             |
+| `GetArray(size_t element) -> ArrayView`                 | Get nested array as child ArrayView       |
 
 ## `TablePath`
 
@@ -632,6 +706,7 @@ inline const char* ChangeTypeShortString(ChangeType ct) {
 | `Timestamp`    | Timestamp without timezone |
 | `TimestampLtz` | Timestamp with timezone    |
 | `Decimal`      | Decimal                    |
+| `Array`        | Array of elements          |
 
 ### `ChangeType`
 

--- a/website/docs/user-guide/cpp/data-types.md
+++ b/website/docs/user-guide/cpp/data-types.md
@@ -21,6 +21,7 @@ sidebar_position: 3
 | `DataType::Timestamp()`    | Timestamp without timezone (default precision 6, microseconds) |
 | `DataType::TimestampLtz()` | Timestamp with timezone (default precision 6, microseconds)    |
 | `DataType::Decimal(p, s)`  | Decimal with precision and scale                               |
+| `DataType::Array(element)` | Array of the given element type (supports nesting)             |
 
 ## GenericRow Setters
 
@@ -36,6 +37,30 @@ row.SetFloat32(4, 3.14f);
 row.SetFloat64(5, 2.71828);
 row.SetString(6, "hello");
 row.SetBytes(7, {0x01, 0x02, 0x03});
+```
+
+### Array Columns
+
+Array values are built element-by-element using `ArrayWriter`, then attached to the row via `SetArray`:
+
+```cpp
+fluss::ArrayWriter aw(3, fluss::DataType::Int());
+aw.SetInt32(0, 10);
+aw.SetInt32(1, 20);
+aw.SetNull(2);
+row.SetArray(8, std::move(aw));
+```
+
+For nested arrays (e.g., `ARRAY<ARRAY<INT>>`), build inner arrays first:
+
+```cpp
+fluss::ArrayWriter inner(2, fluss::DataType::Int());
+inner.SetInt32(0, 1);
+inner.SetInt32(1, 2);
+
+fluss::ArrayWriter outer(1, fluss::DataType::Array(fluss::DataType::Int()));
+outer.SetArray(0, std::move(inner));
+row.SetArray(9, std::move(outer));
 ```
 
 ## Name-Based Setters
@@ -109,6 +134,37 @@ if (result.Found()) {
 }
 ```
 
+### Reading Array Columns
+
+Array columns can be read element-by-element using index-based getters, or via an `ArrayView` for recursive access:
+
+```cpp
+// Element-by-element access (flat arrays)
+size_t len = rec.row.GetArraySize(8);
+for (size_t i = 0; i < len; i++) {
+    if (!rec.row.IsArrayElementNull(8, i)) {
+        int32_t val = rec.row.GetArrayInt32(8, i);
+    }
+}
+
+// ArrayView for nested arrays or when you need a standalone handle
+fluss::ArrayView av = rec.row.GetArrayView(8);
+for (size_t i = 0; i < av.Size(); i++) {
+    if (!av.IsNull(i)) {
+        int32_t val = av.GetInt32(i);
+    }
+}
+
+// Nested arrays: ArrayView::GetArray() returns a child ArrayView
+fluss::ArrayView outer = rec.row.GetArrayView(9);
+for (size_t i = 0; i < outer.Size(); i++) {
+    fluss::ArrayView inner = outer.GetArray(i);
+    for (size_t j = 0; j < inner.Size(); j++) {
+        int32_t val = inner.GetInt32(j);
+    }
+}
+```
+
 ## TypeId Enum
 
 `TinyInt` and `SmallInt` values are widened to `int32_t` on read.
@@ -129,6 +185,7 @@ if (result.Found()) {
 | `Timestamp`     | `Timestamp`                                 | `GetTimestamp(idx)`       |
 | `TimestampLtz`  | `Timestamp`                                 | `GetTimestamp(idx)`       |
 | `Decimal`       | `std::string`                               | `GetDecimalString(idx)`   |
+| `Array`         | `ArrayView`                                 | `GetArrayView(idx)`       |
 
 ## Type Checking
 


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #468 

<!-- What is the purpose of the change -->

### Brief change log
- Adds ARRAY data type support to the C++ bindings and cover full write and read paths (by creating ArrayWriter and ArrayView, also expose in public api)
- Support nested arrays on both write and read 
- Extend GenericRow, RowView and LookupResult with array-typed getters and setters


### Tests

All tests are passed

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
