### PR TITLE
[ci] cache C++ build with sccache

### DIFF
--- a/.github/workflows/build_and_test_cpp.yml
+++ b/.github/workflows/build_and_test_cpp.yml
@@ -60,14 +60,24 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
       - name: Build fluss-test-cluster binary
         run: cargo build -p fluss-test-cluster
 
       - name: Build C++ bindings and tests
         working-directory: bindings/cpp
+        env:
+          SCCACHE_GHA_ENABLED: "true"
         run: |
-          cmake -B build -DFLUSS_ENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
+          cmake -B build \
+            -DFLUSS_ENABLE_TESTING=ON \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           cmake --build build --parallel
+          sccache --show-stats
 
       - name: Run C++ integration tests (parallel)
         working-directory: bindings/cpp


### PR DESCRIPTION
closes https://github.com/apache/fluss-rust/issues/504

The C++ build step takes ~80s per run because there's no compile cache. 
This wires mozilla-actions/sccache-action (ASF-allowlisted, same SHA as apache/iceberg-cpp).

