### PR TITLE
Unify test cluster infrastructure by using Rust cluster in Python tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "arrow-schema",
  "bigdecimal",
  "fluss-rs",
+ "fluss-test-cluster",
  "indexmap 2.13.1",
  "jiff",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +985,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1119,8 @@ dependencies = [
  "jiff",
  "linked-hash-map",
  "log",
+ "metrics",
+ "metrics-util",
  "opendal",
  "ordered-float",
  "parking_lot",
@@ -1404,6 +1421,9 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2056,6 +2076,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.1",
+ "metrics",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,6 +2127,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "num"
@@ -2548,6 +2607,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2724,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,6 +2792,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3214,6 +3316,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -29,6 +29,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.26.0", features = ["extension-module", "generate-import-lib"] }
 fluss = { workspace = true, features = ["storage-all"] }
+fluss-test-cluster = { path = "../../crates/fluss-test-cluster" }
 tokio = { workspace = true }
 arrow = { workspace = true }
 arrow-pyarrow = "57.0.0"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -28,6 +28,7 @@ mod error;
 mod lookup;
 mod metadata;
 mod table;
+mod test_cluster;
 mod upsert;
 mod utils;
 mod write_handle;
@@ -39,6 +40,7 @@ pub use error::*;
 pub use lookup::*;
 pub use metadata::*;
 pub use table::*;
+pub use test_cluster::*;
 pub use upsert::*;
 pub use utils::*;
 pub use write_handle::*;
@@ -130,6 +132,7 @@ fn _fluss(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<WriteResultHandle>()?;
     m.add_class::<DatabaseDescriptor>()?;
     m.add_class::<DatabaseInfo>()?;
+    m.add_class::<FlussTestCluster>()?;
 
     // Register constants
     m.add("EARLIEST_OFFSET", fcore::client::EARLIEST_OFFSET)?;

--- a/bindings/python/src/test_cluster.rs
+++ b/bindings/python/src/test_cluster.rs
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use fluss_test_cluster::{stop_cluster, FlussTestingClusterBuilder};
+use pyo3::prelude::*;
+use pyo3_async_runtimes::tokio::future_into_py;
+
+const DEFAULT_SASL_USERS: &[(&str, &str)] = &[("root", "password"), ("guest", "password2")];
+
+/// Opaque handle to a Fluss testing cluster running in Docker.
+///
+/// Containers are detached from this handle's lifetime — call `stop()` to tear them
+/// down (or rely on the registered atexit cleanup in conftest.py).
+#[pyclass]
+pub struct FlussTestCluster {
+    name: String,
+    #[pyo3(get)]
+    bootstrap_servers: String,
+    #[pyo3(get)]
+    sasl_bootstrap_servers: Option<String>,
+}
+
+#[pymethods]
+impl FlussTestCluster {
+    /// Start (or attach to) a cluster. Idempotent: if containers for `name` already
+    /// exist, returns a handle to the running cluster instead of restarting it.
+    #[staticmethod]
+    #[pyo3(signature = (name, sasl=true, port=None))]
+    fn start<'py>(
+        py: Python<'py>,
+        name: String,
+        sasl: bool,
+        port: Option<u16>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        future_into_py(py, async move {
+            let mut builder = FlussTestingClusterBuilder::new(name.clone());
+            if let Some(p) = port {
+                builder = builder.with_port(p);
+            }
+            if sasl {
+                let users = DEFAULT_SASL_USERS
+                    .iter()
+                    .map(|(u, p)| (u.to_string(), p.to_string()))
+                    .collect();
+                builder = builder.with_sasl(users);
+            }
+
+            let info = builder.build_detached().await;
+
+            let cluster = FlussTestCluster {
+                name,
+                bootstrap_servers: info.bootstrap_servers,
+                sasl_bootstrap_servers: info.sasl_bootstrap_servers,
+            };
+            Python::attach(|py| Py::new(py, cluster))
+        })
+    }
+
+    /// Tear down all containers belonging to this cluster name. Safe to call multiple times.
+    fn stop(&self) -> PyResult<()> {
+        stop_cluster(&self.name);
+        Ok(())
+    }
+
+    /// Stop a named cluster without holding a handle. Useful for atexit cleanup.
+    #[staticmethod]
+    fn stop_by_name(name: &str) -> PyResult<()> {
+        stop_cluster(name);
+        Ok(())
+    }
+
+    #[getter]
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "FlussTestCluster(name={:?}, bootstrap_servers={:?})",
+            self.name, self.bootstrap_servers
+        )
+    }
+}
+

--- a/bindings/python/test/conftest.py
+++ b/bindings/python/test/conftest.py
@@ -16,73 +16,15 @@
 # under the License.
 
 import asyncio
-import json
 import os
-import subprocess
-import tempfile
 import time
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
-from filelock import FileLock
 
 import fluss
 
 CLUSTER_NAME = "shared-test"
-
-
-def _find_cli_binary():
-    env_bin = os.environ.get("FLUSS_TEST_CLUSTER_BIN")
-    if env_bin:
-        if os.path.isfile(env_bin):
-            return env_bin
-        raise FileNotFoundError(f"FLUSS_TEST_CLUSTER_BIN={env_bin!r} does not exist")
-    result = subprocess.run(
-        ["cargo", "locate-project", "--workspace", "--message-format", "plain"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        root = Path(result.stdout.strip()).parent
-        for profile in ("debug", "release"):
-            bin_path = root / "target" / profile / "fluss-test-cluster"
-            if bin_path.is_file():
-                return str(bin_path)
-    raise FileNotFoundError(
-        "fluss-test-cluster not found. Run: cargo build -p fluss-test-cluster"
-    )
-
-
-def _start_cluster():
-    lock = Path(tempfile.gettempdir()) / f"fluss-{CLUSTER_NAME}.lock"
-    with FileLock(lock):
-        cli = _find_cli_binary()
-        result = subprocess.run(
-            [cli, "start", "--sasl", "--name", CLUSTER_NAME],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"fluss-test-cluster start failed:\n{result.stderr}\n{result.stdout}"
-            )
-        prefix = "CLUSTER_JSON: "
-        for line in result.stdout.strip().split("\n"):
-            if line.startswith(prefix):
-                info = json.loads(line[len(prefix) :])
-                return info["bootstrap_servers"], info.get("sasl_bootstrap_servers")
-        raise RuntimeError(
-            f"No CLUSTER_JSON token in output:\n{result.stdout}\n{result.stderr}"
-        )
-
-
-def _stop_cluster():
-    try:
-        cli = _find_cli_binary()
-    except FileNotFoundError:
-        return
-    subprocess.run([cli, "stop", "--name", CLUSTER_NAME], capture_output=True)
 
 
 async def _connect(bootstrap_servers):
@@ -109,7 +51,7 @@ def pytest_unconfigure(config):
         return
     if hasattr(config, "workerinput"):
         return
-    _stop_cluster()
+    fluss.FlussTestCluster.stop_by_name(CLUSTER_NAME)
 
 
 @pytest.fixture(scope="session")
@@ -120,8 +62,16 @@ def fluss_cluster():
         yield (env, sasl_env)
         return
 
-    plaintext_addr, sasl_addr = _start_cluster()
-    yield (plaintext_addr, sasl_addr or plaintext_addr)
+    loop = asyncio.new_event_loop()
+    try:
+        cluster = loop.run_until_complete(
+            fluss.FlussTestCluster.start(CLUSTER_NAME, sasl=True)
+        )
+    finally:
+        loop.close()
+    plaintext_addr = cluster.bootstrap_servers
+    sasl_addr = cluster.sasl_bootstrap_servers or plaintext_addr
+    yield (plaintext_addr, sasl_addr)
 
 
 _cached_connection = None


### PR DESCRIPTION
### Purpose

Linked issue: close #394

Replace Python test setup based on CLI subprocess with direct Rust test cluster integration for simpler and more reliable testing.

---

### Brief change log

- Added `fluss-test-cluster` dependency in `bindings/python/Cargo.toml`
- Added `FlussTestCluster` (`bindings/python/src/test_cluster.rs`):
  - wraps `FlussTestingClusterBuilder::build_detached()`
  - exposes `start`, `stop`, `stop_by_name`, `bootstrap_servers`, `sasl_bootstrap_servers`
- Registered class in `bindings/python/src/lib.rs`
- Refactored Python test setup:
  - removed subprocess / CLI / file lock logic
  - use `FlussTestCluster.start` directly
  - cleanup via `pytest_unconfigure → stop_by_name`

---

### Tests

- Python tests now use in-process Rust cluster manager
- Removed CLI dependency and JSON parsing
- Verified with test runs

---

### API and Format

**API Change:** Yes  
- New `FlussTestCluster` exposed in Python bindings  

**Storage Format:** No  

---

### Documentation

No