### PR TITLE
[chore] reduce workers to 2 with loadfile distribution

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run tests (parallel)
         working-directory: bindings/python
-        run: uv run --no-sync pytest test/ -v -n auto
+        run: uv run --no-sync pytest test/ -v -n 2 --dist=loadfile
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full


### PR DESCRIPTION
By a quick look, i have some ideas of where test flake can happen, and i think we can reduce concurrent workers from 4 to 2 (given unbuntu-latest probably has 4 cores)

Plus, i think usually `loadfile` could be a better distribution strategy than the default in concurrent runs scenario since tests from the same file will go to same worker now.
