### PR TITLE
[python] Support FixedSizeBinary in schema conversion

### DIFF
--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -57,6 +57,7 @@ impl Utils {
             ArrowDataType::Float64 => DataTypes::double(),
             ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 => DataTypes::string(),
             ArrowDataType::Binary | ArrowDataType::LargeBinary => DataTypes::bytes(),
+            ArrowDataType::FixedSizeBinary(n) => DataTypes::binary(*n as usize),
             ArrowDataType::Date32 => DataTypes::date(),
             ArrowDataType::Date64 => DataTypes::date(),
             ArrowDataType::Time32(unit) => match unit {

--- a/bindings/python/test/test_kv_table.py
+++ b/bindings/python/test/test_kv_table.py
@@ -358,6 +358,7 @@ async def test_all_supported_datatypes(connection, admin):
                 pa.field("col_timestamp_ntz", pa.timestamp("us")),
                 pa.field("col_timestamp_ltz", pa.timestamp("us", tz="UTC")),
                 pa.field("col_bytes", pa.binary()),
+                pa.field("col_binary", pa.binary(16)),
             ]
         ),
         primary_keys=["pk_int"],
@@ -385,6 +386,7 @@ async def test_all_supported_datatypes(connection, admin):
         "col_timestamp_ntz": datetime(2026, 1, 23, 10, 13, 47, 123000),
         "col_timestamp_ltz": datetime(2026, 1, 23, 10, 13, 47, 123000),
         "col_bytes": b"binary data",
+        "col_binary": b"binary_data_0123",
     }
 
     handle = upsert_writer.upsert(row_data)
@@ -411,6 +413,7 @@ async def test_all_supported_datatypes(connection, admin):
         2026, 1, 23, 10, 13, 47, 123000, tzinfo=timezone.utc
     )
     assert result["col_bytes"] == b"binary data"
+    assert result["col_binary"] == b"binary_data_0123"
 
     # Test with null values for all nullable columns
     null_row = {"pk_int": 2}

--- a/website/docs/user-guide/python/data-types.md
+++ b/website/docs/user-guide/python/data-types.md
@@ -12,6 +12,7 @@ The Python client uses PyArrow types for schema definitions:
 | `pa.float32()` / `float64()`                    | Float / Double                    | `float`             |
 | `pa.string()`                                   | String                            | `str`               |
 | `pa.binary()`                                   | Bytes                             | `bytes`             |
+| `pa.binary(n)`                                  | Binary(n)                         | `bytes`             |
 | `pa.date32()`                                   | Date                              | `datetime.date`     |
 | `pa.time32("ms")`                               | Time                              | `datetime.time`     |
 | `pa.timestamp("us")`                            | Timestamp (NTZ)                   | `datetime.datetime` |


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss-rust/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

Add pa.binary(n) -> Fluss BINARY(n) mapping in Python binding's

Linked issue: close #524 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

Yes
