### PR TITLE
[test][chore] Capture cluster container logs as CI artifact

### DIFF
--- a/.github/workflows/build_and_test_python.yml
+++ b/.github/workflows/build_and_test_python.yml
@@ -81,3 +81,20 @@ jobs:
         env:
           RUST_LOG: DEBUG
           RUST_BACKTRACE: full
+          FLUSS_SKIP_CLUSTER_TEARDOWN: "1"
+
+      - name: Dump fluss cluster container logs
+        if: always()
+        run: |
+          mkdir -p cluster-logs
+          for c in $(docker ps -a --filter "name=shared-test" --format '{{.Names}}'); do
+            docker logs "$c" > "cluster-logs/$c.log" 2>&1 || true
+          done
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cluster-logs-${{ matrix.python }}
+          path: cluster-logs/
+          if-no-files-found: ignore
+          retention-days: 3

--- a/bindings/python/test/conftest.py
+++ b/bindings/python/test/conftest.py
@@ -109,6 +109,8 @@ def pytest_unconfigure(config):
         return
     if hasattr(config, "workerinput"):
         return
+    if os.environ.get("FLUSS_SKIP_CLUSTER_TEARDOWN"):
+        return
     _stop_cluster()
 
 


### PR DESCRIPTION
### Purpose

Small follow-up from https://github.com/apache/fluss-rust/pull/529, in current timeout failure, if there is fluss cluster container error, we do not see the logs, and this hinders us to understand where it goes wrong for debugging.

So one idea is to save those logs. Here try to capture container logs as CI artifacts that can be downloaded.

This won't affect local development because cluster will be stopped as how it works, but in CI, cluster won't be stopped until pytest finishes, and it should be safe because CI runners are ephemeral VMs, so they should be destroyed after the job.