### PR TITLE
chore: fix main broken due to new clippy useless_conversion

### DIFF
--- a/crates/fluss/src/client/lookup/lookup_sender.rs
+++ b/crates/fluss/src/client/lookup/lookup_sender.rs
@@ -197,7 +197,7 @@ impl<T> LookupBatch<T> {
             return;
         }
 
-        for (lookup, value) in self.lookups.iter_mut().zip(values.into_iter()) {
+        for (lookup, value) in self.lookups.iter_mut().zip(values) {
             lookup.complete(Ok(value));
         }
     }


### PR DESCRIPTION
Rust stable rolled from 1.94 -> 1.95
clippy now has new check for useless_conversions, so fixing this