### PR TITLE
[elixir] feat: Extend Fluss.Config with security, SASL and connect timeout options

### DIFF
--- a/bindings/elixir/lib/fluss/config.ex
+++ b/bindings/elixir/lib/fluss/config.ex
@@ -33,6 +33,7 @@ defmodule Fluss.Config do
 
   @enforce_keys [:bootstrap_servers]
   defstruct bootstrap_servers: nil,
+            connect_timeout_ms: nil,
             remote_file_download_thread_num: nil,
             scanner_log_fetch_max_bytes: nil,
             scanner_log_fetch_max_bytes_for_bucket: nil,
@@ -41,6 +42,10 @@ defmodule Fluss.Config do
             scanner_log_max_poll_records: nil,
             scanner_remote_log_prefetch_num: nil,
             scanner_remote_log_read_concurrency: nil,
+            security_protocol: nil,
+            security_sasl_mechanism: nil,
+            security_sasl_password: nil,
+            security_sasl_username: nil,
             writer_acks: nil,
             writer_batch_size: nil,
             writer_batch_timeout_ms: nil,
@@ -56,6 +61,7 @@ defmodule Fluss.Config do
 
   @type t :: %__MODULE__{
           bootstrap_servers: String.t(),
+          connect_timeout_ms: non_neg_integer() | nil,
           remote_file_download_thread_num: non_neg_integer() | nil,
           scanner_log_fetch_max_bytes: non_neg_integer() | nil,
           scanner_log_fetch_max_bytes_for_bucket: non_neg_integer() | nil,
@@ -64,6 +70,10 @@ defmodule Fluss.Config do
           scanner_log_max_poll_records: non_neg_integer() | nil,
           scanner_remote_log_prefetch_num: non_neg_integer() | nil,
           scanner_remote_log_read_concurrency: non_neg_integer() | nil,
+          security_protocol: String.t() | nil,
+          security_sasl_mechanism: String.t() | nil,
+          security_sasl_password: String.t() | nil,
+          security_sasl_username: String.t() | nil,
           writer_acks: String.t() | nil,
           writer_batch_size: non_neg_integer() | nil,
           writer_batch_timeout_ms: non_neg_integer() | nil,
@@ -89,6 +99,10 @@ defmodule Fluss.Config do
   @spec set_bootstrap_servers(t(), String.t()) :: t()
   def set_bootstrap_servers(%__MODULE__{} = config, servers) when is_binary(servers),
     do: %{config | bootstrap_servers: servers}
+
+  @spec set_connect_timeout_ms(t(), non_neg_integer()) :: t()
+  def set_connect_timeout_ms(%__MODULE__{} = config, ms) when is_integer(ms),
+    do: %{config | connect_timeout_ms: ms}
 
   @spec set_remote_file_download_thread_num(t(), non_neg_integer()) :: t()
   def set_remote_file_download_thread_num(%__MODULE__{} = config, threads)
@@ -127,6 +141,22 @@ defmodule Fluss.Config do
   def set_scanner_remote_log_read_concurrency(%__MODULE__{} = config, concurrency)
       when is_integer(concurrency),
       do: %{config | scanner_remote_log_read_concurrency: concurrency}
+
+  @spec set_security_protocol(t(), String.t()) :: t()
+  def set_security_protocol(%__MODULE__{} = config, protocol) when is_binary(protocol),
+    do: %{config | security_protocol: protocol}
+
+  @spec set_security_sasl_mechanism(t(), String.t()) :: t()
+  def set_security_sasl_mechanism(%__MODULE__{} = config, mechanism) when is_binary(mechanism),
+    do: %{config | security_sasl_mechanism: mechanism}
+
+  @spec set_security_sasl_password(t(), String.t()) :: t()
+  def set_security_sasl_password(%__MODULE__{} = config, pass) when is_binary(pass),
+    do: %{config | security_sasl_password: pass}
+
+  @spec set_security_sasl_username(t(), String.t()) :: t()
+  def set_security_sasl_username(%__MODULE__{} = config, username) when is_binary(username),
+    do: %{config | security_sasl_username: username}
 
   @spec set_writer_acks(t(), String.t()) :: t()
   def set_writer_acks(%__MODULE__{} = config, acks) when is_binary(acks),
@@ -182,4 +212,28 @@ defmodule Fluss.Config do
 
   @spec get_bootstrap_servers(t()) :: String.t()
   def get_bootstrap_servers(%__MODULE__{bootstrap_servers: servers}), do: servers
+end
+
+defimpl Inspect, for: Fluss.Config do
+  import Inspect.Algebra
+
+  def inspect(%Fluss.Config{} = config, opts) do
+    sanitized = %{config | security_sasl_password: redact(config.security_sasl_password)}
+
+    fields = sanitized |> Map.from_struct() |> Map.to_list()
+
+    container_doc(
+      "%Fluss.Config{",
+      fields,
+      "}",
+      opts,
+      fn {key, value}, opts ->
+        concat([Atom.to_string(key), ": ", to_doc(value, opts)])
+      end,
+      separator: ","
+    )
+  end
+
+  defp redact(nil), do: nil
+  defp redact(_), do: "[REDACTED]"
 end

--- a/bindings/elixir/native/fluss_nif/src/config.rs
+++ b/bindings/elixir/native/fluss_nif/src/config.rs
@@ -31,6 +31,7 @@ pub enum NifNoKeyAssigner {
 #[module = "Fluss.Config"]
 pub struct NifConfig {
     pub bootstrap_servers: String,
+    pub connect_timeout_ms: Option<u64>,
     pub remote_file_download_thread_num: Option<u64>,
     pub scanner_log_fetch_max_bytes: Option<i32>,
     pub scanner_log_fetch_max_bytes_for_bucket: Option<i32>,
@@ -39,6 +40,10 @@ pub struct NifConfig {
     pub scanner_log_max_poll_records: Option<u64>,
     pub scanner_remote_log_prefetch_num: Option<u64>,
     pub scanner_remote_log_read_concurrency: Option<u64>,
+    pub security_protocol: Option<String>,
+    pub security_sasl_mechanism: Option<String>,
+    pub security_sasl_password: Option<String>,
+    pub security_sasl_username: Option<String>,
     pub writer_acks: Option<String>,
     pub writer_batch_size: Option<i32>,
     pub writer_batch_timeout_ms: Option<i64>,
@@ -59,6 +64,9 @@ impl NifConfig {
             bootstrap_servers: self.bootstrap_servers,
             ..Config::default()
         };
+        if let Some(timeout) = self.connect_timeout_ms {
+            config.connect_timeout_ms = timeout;
+        }
         if let Some(n) = self.remote_file_download_thread_num {
             config.remote_file_download_thread_num = n as usize;
         }
@@ -82,6 +90,18 @@ impl NifConfig {
         }
         if let Some(n) = self.scanner_remote_log_read_concurrency {
             config.scanner_remote_log_read_concurrency = n as usize;
+        }
+        if let Some(protocol) = self.security_protocol {
+            config.security_protocol = protocol;
+        }
+        if let Some(mechanism) = self.security_sasl_mechanism {
+            config.security_sasl_mechanism = mechanism;
+        }
+        if let Some(password) = self.security_sasl_password {
+            config.security_sasl_password = password;
+        }
+        if let Some(username) = self.security_sasl_username {
+            config.security_sasl_username = username;
         }
         if let Some(size) = self.writer_batch_size {
             config.writer_batch_size = size;

--- a/bindings/elixir/test/config_test.exs
+++ b/bindings/elixir/test/config_test.exs
@@ -23,6 +23,14 @@ defmodule Fluss.ConfigTest do
     assert config == %Fluss.Config{bootstrap_servers: "localhost:9123"}
   end
 
+  test "set_connect_timeout_ms/2 sets the connect timeout" do
+    config =
+      Fluss.Config.new("localhost:9123")
+      |> Fluss.Config.set_connect_timeout_ms(30_000)
+
+    assert config.connect_timeout_ms == 30_000
+  end
+
   test "set_remote_file_download_thread_num/2 sets the download thread num" do
     config =
       Fluss.Config.new("localhost:9123")
@@ -85,6 +93,54 @@ defmodule Fluss.ConfigTest do
       |> Fluss.Config.set_scanner_remote_log_read_concurrency(4)
 
     assert config.scanner_remote_log_read_concurrency == 4
+  end
+
+  test "set_security_protocol/2 sets the security protocol" do
+    config =
+      Fluss.Config.new("localhost:9123")
+      |> Fluss.Config.set_security_protocol("sasl")
+
+    assert config.security_protocol == "sasl"
+  end
+
+  test "set_security_sasl_mechanism/2 sets the SASL mechanism" do
+    config =
+      Fluss.Config.new("localhost:9123")
+      |> Fluss.Config.set_security_sasl_mechanism("PLAIN")
+
+    assert config.security_sasl_mechanism == "PLAIN"
+  end
+
+  test "set_security_sasl_username/2 sets the SASL username" do
+    config =
+      Fluss.Config.new("localhost:9123")
+      |> Fluss.Config.set_security_sasl_username("admin")
+
+    assert config.security_sasl_username == "admin"
+  end
+
+  test "set_security_sasl_password/2 sets the SASL password" do
+    config =
+      Fluss.Config.new("localhost:9123")
+      |> Fluss.Config.set_security_sasl_password("secret")
+
+    assert config.security_sasl_password == "secret"
+  end
+
+  test "inspect/1 redacts security_sasl_password when set" do
+    config =
+      Fluss.Config.new("localhost:9123")
+      |> Fluss.Config.set_security_sasl_password("supersecret")
+
+    output = inspect(config)
+    refute output =~ "supersecret"
+    assert output =~ "[REDACTED]"
+  end
+
+  test "inspect/1 leaves nil security_sasl_password as nil" do
+    config = Fluss.Config.new("localhost:9123")
+    output = inspect(config)
+    assert output =~ "security_sasl_password: nil"
   end
 
   test "set_writer_acks/2 sets the acks value" do


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss-rust/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #569 and the parent #463. 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

This PR follows up on #574 to extend Fluss.Config with configuration options for security protocol, SASL and connect timeout. To ensure that the SASL password, if set, gets redacted in logs, we customise how Fluss.Config gets inspected using the [Inspect protocol](https://hexdocs.pm/elixir/Inspect.html); it would appear as `[REDACTED]` in logs.

We otherwise follow the same approach as in the related PRs.

### Tests

New tests cover the setters that were added for these options, one for each function.

<!-- List UT and IT cases to verify this change -->