### PR TITLE
[rust] typed column-vector dispatch

### DIFF
--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -2400,7 +2400,10 @@ mod row_reader {
         validate(row, columns, field, "get_array", |dt| {
             matches!(dt, fcore::metadata::DataType::Array(_))
         })?;
-        row.get_array(field).map_err(|e| e.to_string())
+        row.get_array(field)
+            .map_err(|e| e.to_string())?
+            .try_into_binary()
+            .map_err(|e| e.to_string())
     }
 
     pub fn get_array_element_type(

--- a/bindings/cpp/src/types.rs
+++ b/bindings/cpp/src/types.rs
@@ -588,8 +588,10 @@ pub fn compacted_row_to_owned(
             fcore::metadata::DataType::Binary(dt) => {
                 Datum::Blob(Cow::Owned(row.get_binary(i, dt.length())?.to_vec()))
             }
-            fcore::metadata::DataType::Array(_) => Datum::Array(row.get_array(i)?),
-            fcore::metadata::DataType::Map(_) => Datum::Map(row.get_map(i)?),
+            fcore::metadata::DataType::Array(_) => {
+                Datum::Array(row.get_array(i)?.try_into_binary()?)
+            }
+            fcore::metadata::DataType::Map(_) => Datum::Map(row.get_map(i)?.try_into_binary()?),
             other => return Err(anyhow!("Unsupported data type for column {i}: {other:?}")),
         };
 

--- a/bindings/python/src/table.rs
+++ b/bindings/python/src/table.rs
@@ -1519,6 +1519,8 @@ pub fn datum_to_python_value(
         DataType::Array(array_type) => {
             let array_data = row
                 .get_array(pos)
+                .map_err(|e| FlussError::from_core_error(&e))?
+                .try_into_binary()
                 .map_err(|e| FlussError::from_core_error(&e))?;
 
             let element_type = array_type.get_element_type();

--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -208,8 +208,9 @@ impl Utils {
             let columnar_row = record.row();
             let row_id = columnar_row.get_row_id();
             if row_id == 0 {
-                let record_batch = columnar_row.get_record_batch();
-                result.push(Arc::new(record_batch.clone()));
+                if let Some(record_batch) = columnar_row.get_record_batch() {
+                    result.push(Arc::new(record_batch.clone()));
+                }
             }
         }
         result

--- a/crates/examples/src/example_kv_table.rs
+++ b/crates/examples/src/example_kv_table.rs
@@ -20,7 +20,7 @@ use fluss::client::FlussConnection;
 use fluss::config::Config;
 use fluss::error::Result;
 use fluss::metadata::{DataTypes, Schema, TableDescriptor, TablePath};
-use fluss::row::{GenericRow, InternalRow};
+use fluss::row::{DataGetters, GenericRow};
 
 #[tokio::main]
 #[allow(dead_code)]

--- a/crates/examples/src/example_partitioned_kv_table.rs
+++ b/crates/examples/src/example_partitioned_kv_table.rs
@@ -20,7 +20,7 @@ use fluss::client::{FlussAdmin, FlussConnection};
 use fluss::config::Config;
 use fluss::error::Result;
 use fluss::metadata::{DataTypes, PartitionSpec, Schema, TableDescriptor, TablePath};
-use fluss::row::{GenericRow, InternalRow};
+use fluss::row::{DataGetters, GenericRow};
 use std::collections::HashMap;
 
 #[tokio::main]

--- a/crates/examples/src/example_partitioned_prefix_lookup.rs
+++ b/crates/examples/src/example_partitioned_prefix_lookup.rs
@@ -20,7 +20,7 @@ use fluss::client::{FlussAdmin, FlussConnection};
 use fluss::config::Config;
 use fluss::error::Result;
 use fluss::metadata::{DataTypes, PartitionSpec, Schema, TableDescriptor, TablePath};
-use fluss::row::{GenericRow, InternalRow};
+use fluss::row::{DataGetters, GenericRow};
 use std::collections::HashMap;
 
 #[tokio::main]

--- a/crates/examples/src/example_prefix_lookup.rs
+++ b/crates/examples/src/example_prefix_lookup.rs
@@ -20,7 +20,7 @@ use fluss::client::FlussConnection;
 use fluss::config::Config;
 use fluss::error::Result;
 use fluss::metadata::{DataTypes, Schema, TableDescriptor, TablePath};
-use fluss::row::{GenericRow, InternalRow};
+use fluss::row::{DataGetters, GenericRow};
 
 #[tokio::main]
 #[allow(dead_code)]

--- a/crates/examples/src/example_table.rs
+++ b/crates/examples/src/example_table.rs
@@ -27,7 +27,7 @@ use fluss::client::FlussConnection;
 use fluss::config::Config;
 use fluss::error::Result;
 use fluss::metadata::{DataTypes, Schema, TableDescriptor, TablePath};
-use fluss::row::{GenericRow, InternalRow};
+use fluss::row::{DataGetters, GenericRow};
 use std::time::Duration;
 
 #[tokio::main]

--- a/crates/fluss/src/client/table/append.rs
+++ b/crates/fluss/src/client/table/append.rs
@@ -131,7 +131,7 @@ impl AppendWriter {
                 Arc::new(self.table_info.row_type.clone()),
                 0,
                 None,
-            );
+            )?;
             Arc::new(get_physical_path(
                 &self.table_path,
                 self.partition_getter.as_ref(),

--- a/crates/fluss/src/client/table/lookup.rs
+++ b/crates/fluss/src/client/table/lookup.rs
@@ -626,6 +626,7 @@ impl PrefixKeyLookuper {
 mod tests {
     use super::*;
     use crate::metadata::{Column, DataTypes, Schema};
+    use crate::row::DataGetters;
     use crate::row::binary::BinaryWriter;
     use crate::row::compacted::CompactedRowWriter;
     use arrow::array::Int32Array;

--- a/crates/fluss/src/client/table/scanner.rs
+++ b/crates/fluss/src/client/table/scanner.rs
@@ -174,7 +174,7 @@ impl<'a> TableScan<'a> {
     /// # use fluss::config::Config;
     /// # use fluss::error::Result;
     /// # use fluss::metadata::{DataTypes, Schema, TableDescriptor, TablePath};
-    /// # use fluss::row::InternalRow;
+    /// # use fluss::row::{DataGetters, InternalRow};
     /// # use std::time::Duration;
     ///
     /// # pub async fn example() -> Result<()> {
@@ -250,7 +250,7 @@ impl<'a> TableScan<'a> {
     /// # use fluss::config::Config;
     /// # use fluss::error::Result;
     /// # use fluss::metadata::{DataTypes, Schema, TableDescriptor, TablePath};
-    /// # use fluss::row::InternalRow;
+    /// # use fluss::row::{DataGetters, InternalRow};
     /// # use std::time::Duration;
     ///
     /// # pub async fn example() -> Result<()> {

--- a/crates/fluss/src/lib.rs
+++ b/crates/fluss/src/lib.rs
@@ -32,7 +32,7 @@
 //! use fluss::config::Config;
 //! use fluss::error::Result;
 //! use fluss::metadata::{DataTypes, Schema, TableDescriptor, TablePath};
-//! use fluss::row::{GenericRow, InternalRow};
+//! use fluss::row::{DataGetters, GenericRow, InternalRow};
 //! use std::time::Duration;
 //!
 //! #[tokio::main]

--- a/crates/fluss/src/record/arrow.rs
+++ b/crates/fluss/src/record/arrow.rs
@@ -22,8 +22,9 @@ use crate::compression::{
 use crate::error::{Error, Result};
 use crate::metadata::{DataField, DataType, RowType};
 use crate::record::{ChangeType, ScanRecord};
+use crate::row::column_vector::TypedBatch;
 use crate::row::column_writer::{ColumnWriter, round_up_to_8};
-use crate::row::{ColumnarRow, InternalRow, arrow_row_column_indices, fluss_row_column_indices};
+use crate::row::{ColumnarRow, InternalRow};
 use arrow::array::{ArrayBuilder, ArrayRef};
 use arrow::{
     array::RecordBatch,
@@ -1667,21 +1668,12 @@ impl Iterator for ArrowLogRecordIterator {
 }
 
 pub struct ArrowReader {
-    record_batch: Arc<RecordBatch>,
-    row_type: Arc<RowType>,
-    fluss_row_type: Option<Arc<RowType>>,
-    row_column_indices: Arc<[usize]>,
+    batch: Arc<TypedBatch>,
 }
 
 impl ArrowReader {
     pub fn new(record_batch: Arc<RecordBatch>, row_type: Arc<RowType>) -> Self {
-        let row_column_indices = arrow_row_column_indices(&record_batch);
-        ArrowReader {
-            record_batch,
-            row_type,
-            fluss_row_type: None,
-            row_column_indices,
-        }
+        Self::new_with_fluss_row_type(record_batch, row_type, None)
     }
 
     pub fn new_with_fluss_row_type(
@@ -1689,30 +1681,20 @@ impl ArrowReader {
         row_type: Arc<RowType>,
         fluss_row_type: Option<Arc<RowType>>,
     ) -> Self {
-        let row_column_indices = match &fluss_row_type {
-            Some(rt) => fluss_row_column_indices(rt),
-            None => arrow_row_column_indices(&record_batch),
-        };
+        let schema = fluss_row_type.as_deref().unwrap_or(&row_type);
+        let typed = TypedBatch::build(&record_batch, schema)
+            .expect("ArrowReader: TypedBatch::build failed — schema mismatch in scan setup");
         ArrowReader {
-            record_batch,
-            row_type,
-            fluss_row_type,
-            row_column_indices,
+            batch: Arc::new(typed),
         }
     }
 
     pub fn row_count(&self) -> usize {
-        self.record_batch.num_rows()
+        self.batch.num_rows
     }
 
     pub fn read(&self, row_id: usize) -> ColumnarRow {
-        ColumnarRow::with_indices(
-            self.record_batch.clone(),
-            self.row_type.clone(),
-            row_id,
-            self.fluss_row_type.clone(),
-            self.row_column_indices.clone(),
-        )
+        ColumnarRow::from_typed_batch(Arc::clone(&self.batch), row_id)
     }
 }
 pub struct MyVec<T>(pub StreamReader<T>);

--- a/crates/fluss/src/record/arrow.rs
+++ b/crates/fluss/src/record/arrow.rs
@@ -997,7 +997,7 @@ impl LogRecordBatch {
             Arc::new(record_batch),
             read_context.row_type.clone(),
             read_context.fluss_row_type().cloned(),
-        );
+        )?;
         let log_record_iterator = LogRecordIterator::Arrow(ArrowLogRecordIterator {
             reader: arrow_reader,
             base_offset: self.base_log_offset(),
@@ -1024,7 +1024,7 @@ impl LogRecordBatch {
                     Arc::new(record_batch),
                     read_context.row_type.clone(),
                     read_context.fluss_row_type().cloned(),
-                );
+                )?;
                 LogRecordIterator::Arrow(ArrowLogRecordIterator {
                     reader: arrow_reader,
                     base_offset: self.base_log_offset(),
@@ -1672,7 +1672,7 @@ pub struct ArrowReader {
 }
 
 impl ArrowReader {
-    pub fn new(record_batch: Arc<RecordBatch>, row_type: Arc<RowType>) -> Self {
+    pub fn new(record_batch: Arc<RecordBatch>, row_type: Arc<RowType>) -> Result<Self> {
         Self::new_with_fluss_row_type(record_batch, row_type, None)
     }
 
@@ -1680,13 +1680,12 @@ impl ArrowReader {
         record_batch: Arc<RecordBatch>,
         row_type: Arc<RowType>,
         fluss_row_type: Option<Arc<RowType>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let schema = fluss_row_type.as_deref().unwrap_or(&row_type);
-        let typed = TypedBatch::build(&record_batch, schema)
-            .expect("ArrowReader: TypedBatch::build failed — schema mismatch in scan setup");
-        ArrowReader {
+        let typed = TypedBatch::build(&record_batch, schema)?;
+        Ok(ArrowReader {
             batch: Arc::new(typed),
-        }
+        })
     }
 
     pub fn row_count(&self) -> usize {

--- a/crates/fluss/src/record/kv/kv_record_batch.rs
+++ b/crates/fluss/src/record/kv/kv_record_batch.rs
@@ -373,7 +373,7 @@ mod tests {
     use crate::metadata::{DataTypes, KvFormat};
     use crate::record::kv::test_util::TestReadContext;
     use crate::record::kv::{CURRENT_KV_MAGIC_VALUE, KvRecordBatchBuilder};
-    use crate::row::InternalRow;
+    use crate::row::DataGetters;
     use crate::row::binary::BinaryWriter;
 
     use bytes::{BufMut, BytesMut};

--- a/crates/fluss/src/record/kv/kv_record_batch_builder.rs
+++ b/crates/fluss/src/record/kv/kv_record_batch_builder.rs
@@ -319,6 +319,8 @@ impl Drop for KvRecordBatchBuilder {
 mod tests {
     use super::*;
     use crate::metadata::{DataTypes, RowType};
+    use crate::record::kv::KvRecordBatch;
+    use crate::row::DataGetters;
     use crate::row::binary::BinaryWriter;
     use crate::row::compacted::{CompactedRow, CompactedRowWriter};
     use std::sync::LazyLock;
@@ -497,9 +499,6 @@ mod tests {
 
     #[test]
     fn test_builder_with_compacted_row_writer() -> crate::error::Result<()> {
-        use crate::record::kv::KvRecordBatch;
-        use crate::row::InternalRow;
-
         let mut builder = KvRecordBatchBuilder::new(1, 100000, KvFormat::COMPACTED);
         builder.set_writer_state(100, 5);
 

--- a/crates/fluss/src/record/mod.rs
+++ b/crates/fluss/src/record/mod.rs
@@ -253,7 +253,7 @@ mod tests {
         let row_type = Arc::new(RowType::with_data_types(vec![
             crate::metadata::DataType::Int(crate::metadata::IntType::new()),
         ]));
-        ColumnarRow::new(Arc::new(batch), row_type, row_id, None)
+        ColumnarRow::new(Arc::new(batch), row_type, row_id, None).expect("ColumnarRow")
     }
 
     #[test]

--- a/crates/fluss/src/row/binary_array.rs
+++ b/crates/fluss/src/row/binary_array.rs
@@ -28,12 +28,13 @@ use crate::error::Error::IllegalArgument;
 use crate::error::Result;
 use crate::metadata::{DataType, RowType};
 use crate::row::Decimal;
-use crate::row::InternalRow;
 use crate::row::binary::{BinaryRowFormat, ValueWriter};
 use crate::row::binary_map::FlussMap;
 use crate::row::compacted::{CompactedRow, CompactedRowWriter, calculate_bit_set_width_in_bytes};
 use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz};
 use crate::row::field_getter::FieldGetter;
+use crate::row::view::ArrayView;
+use crate::row::{DataGetters, InternalArray, InternalRow};
 use bytes::Bytes;
 use serde::Serialize;
 use std::fmt;
@@ -768,79 +769,74 @@ impl InternalRow for FlussArray {
     fn get_field_count(&self) -> usize {
         self.size()
     }
+}
 
+impl InternalArray for FlussArray {
+    fn size(&self) -> usize {
+        FlussArray::size(self)
+    }
+}
+
+impl DataGetters for FlussArray {
     fn is_null_at(&self, pos: usize) -> Result<bool> {
-        Ok(self.is_null_at(pos))
+        Ok(FlussArray::is_null_at(self, pos))
     }
 
     fn get_boolean(&self, pos: usize) -> Result<bool> {
-        self.get_boolean(pos)
+        FlussArray::get_boolean(self, pos)
     }
     fn get_byte(&self, pos: usize) -> Result<i8> {
-        self.get_byte(pos)
+        FlussArray::get_byte(self, pos)
     }
     fn get_short(&self, pos: usize) -> Result<i16> {
-        self.get_short(pos)
+        FlussArray::get_short(self, pos)
     }
     fn get_int(&self, pos: usize) -> Result<i32> {
-        self.get_int(pos)
+        FlussArray::get_int(self, pos)
     }
     fn get_long(&self, pos: usize) -> Result<i64> {
-        self.get_long(pos)
+        FlussArray::get_long(self, pos)
     }
     fn get_float(&self, pos: usize) -> Result<f32> {
-        self.get_float(pos)
+        FlussArray::get_float(self, pos)
     }
     fn get_double(&self, pos: usize) -> Result<f64> {
-        self.get_double(pos)
+        FlussArray::get_double(self, pos)
     }
 
     fn get_char(&self, pos: usize, _length: usize) -> Result<&str> {
-        self.get_string(pos)
+        FlussArray::get_string(self, pos)
     }
-
     fn get_string(&self, pos: usize) -> Result<&str> {
-        self.get_string(pos)
+        FlussArray::get_string(self, pos)
     }
 
     fn get_decimal(&self, pos: usize, precision: usize, scale: usize) -> Result<Decimal> {
-        self.get_decimal(pos, precision as u32, scale as u32)
+        FlussArray::get_decimal(self, pos, precision as u32, scale as u32)
     }
 
     fn get_date(&self, pos: usize) -> Result<Date> {
-        self.get_date(pos)
+        FlussArray::get_date(self, pos)
     }
     fn get_time(&self, pos: usize) -> Result<Time> {
-        self.get_time(pos)
+        FlussArray::get_time(self, pos)
     }
     fn get_timestamp_ntz(&self, pos: usize, precision: u32) -> Result<TimestampNtz> {
-        self.get_timestamp_ntz(pos, precision)
+        FlussArray::get_timestamp_ntz(self, pos, precision)
     }
     fn get_timestamp_ltz(&self, pos: usize, precision: u32) -> Result<TimestampLtz> {
-        self.get_timestamp_ltz(pos, precision)
+        FlussArray::get_timestamp_ltz(self, pos, precision)
     }
 
     fn get_binary(&self, pos: usize, _length: usize) -> Result<&[u8]> {
-        self.get_binary(pos)
+        FlussArray::get_binary(self, pos)
     }
-
     fn get_bytes(&self, pos: usize) -> Result<&[u8]> {
-        self.get_binary(pos)
+        FlussArray::get_binary(self, pos)
     }
 
-    fn get_array(&self, pos: usize) -> Result<FlussArray> {
-        self.get_array(pos)
-    }
-
-    fn get_map(&self, pos: usize) -> Result<FlussMap> {
-        // FlussArray carries no schema; nested map reads must go through the
-        // inherent FlussArray::get_map(pos, key_type, value_type).
-        Err(IllegalArgument {
-            message: format!(
-                "InternalRow::get_map is not supported on FlussArray (pos {pos}); \
-                 use FlussArray::get_map(pos, key_type, value_type) directly"
-            ),
-        })
+    fn get_array(&self, pos: usize) -> Result<ArrayView<'_>> {
+        Ok(ArrayView::Binary(FlussArray::get_array(self, pos)?))
     }
 }
 
@@ -851,6 +847,23 @@ mod tests {
     use crate::row::binary::BinaryWriter as BinaryWriterTrait;
     use crate::row::compacted::CompactedRowWriter;
     use crate::row::{Datum, GenericRow};
+
+    #[test]
+    fn fluss_array_dispatches_through_internal_array_trait() {
+        let mut writer = FlussArrayWriter::new(3, &DataTypes::int());
+        writer.write_int(0, 10);
+        writer.set_null_at(1);
+        writer.write_int(2, 30);
+        let arr = writer.complete().unwrap();
+
+        let view: &dyn InternalArray = &arr;
+        assert_eq!(view.size(), 3);
+        assert!(!view.is_null_at(0).unwrap());
+        assert!(view.is_null_at(1).unwrap());
+        assert!(!view.is_null_at(2).unwrap());
+        assert_eq!(view.get_int(0).unwrap(), 10);
+        assert_eq!(view.get_int(2).unwrap(), 30);
+    }
 
     #[test]
     fn test_header_calculation() {
@@ -1169,7 +1182,7 @@ mod tests {
         let r1_tags = r1.get_array(0).unwrap();
         assert_eq!(r1_tags.size(), 3);
         assert_eq!(r1_tags.get_string(0).unwrap(), "x");
-        assert!(r1_tags.is_null_at(1));
+        assert!(r1_tags.is_null_at(1).unwrap());
         assert_eq!(r1_tags.get_string(2).unwrap(), "z");
     }
 
@@ -1207,7 +1220,7 @@ mod tests {
         let bytes = writer.to_bytes();
 
         let outer_compacted = CompactedRow::from_bytes(outer_row_type, &bytes);
-        let recovered_arr = outer_compacted.get_array(0).unwrap();
+        let recovered_arr = outer_compacted.get_array(0).unwrap().expect_binary();
         assert_eq!(recovered_arr.size(), 2);
 
         let recovered_r0 = recovered_arr.get_row(0, inner_row_type).unwrap();

--- a/crates/fluss/src/row/binary_map.rs
+++ b/crates/fluss/src/row/binary_map.rs
@@ -27,6 +27,7 @@ use crate::error::Result;
 use crate::metadata::DataType;
 use crate::row::binary_array::{FlussArray, FlussArrayWriter};
 use crate::row::datum::{Datum, read_datum_from_fluss_array};
+use crate::row::{InternalArray, InternalMap};
 use bytes::Bytes;
 use serde::Serialize;
 use std::fmt;
@@ -302,6 +303,20 @@ impl FlussMap {
     }
 }
 
+impl InternalMap for FlussMap {
+    fn size(&self) -> usize {
+        FlussMap::size(self)
+    }
+
+    fn key_array(&self) -> &dyn InternalArray {
+        FlussMap::key_array(self)
+    }
+
+    fn value_array(&self) -> &dyn InternalArray {
+        FlussMap::value_array(self)
+    }
+}
+
 pub struct Entries<'a> {
     map: &'a FlussMap,
     index: usize,
@@ -448,6 +463,24 @@ mod tests {
     use super::*;
     use crate::metadata::DataTypes;
     use crate::row::binary_array::FlussArrayWriter;
+
+    #[test]
+    fn fluss_map_dispatches_through_internal_map_trait() {
+        let mut writer = FlussMapWriter::new(2, &DataTypes::int(), &DataTypes::string());
+        writer.write_entry(1.into(), "a".into()).unwrap();
+        writer.write_entry(2.into(), "b".into()).unwrap();
+        let map = writer.complete().unwrap();
+
+        let view: &dyn InternalMap = &map;
+        assert_eq!(view.size(), 2);
+        let keys = view.key_array();
+        let values = view.value_array();
+        assert_eq!(keys.size(), 2);
+        assert_eq!(keys.get_int(0).unwrap(), 1);
+        assert_eq!(keys.get_int(1).unwrap(), 2);
+        assert_eq!(values.get_string(0).unwrap(), "a");
+        assert_eq!(values.get_string(1).unwrap(), "b");
+    }
 
     #[test]
     fn test_round_trip_int_to_string_map() {

--- a/crates/fluss/src/row/column.rs
+++ b/crates/fluss/src/row/column.rs
@@ -15,1197 +15,246 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Arrow scan-path cursor over a typed column-vector batch. Accessors are a
+//! single match arm with no per-call downcasting. Nested `ARRAY` / `MAP` /
+//! `ROW` reads return columnar slice/cursor views borrowed from the buffers.
+
 use crate::error::Error::IllegalArgument;
 use crate::error::Result;
-use crate::metadata::{DataType, RowType};
+use crate::metadata::{DataField, RowType};
 use crate::record::from_arrow_field;
-use crate::row::binary_array::FlussArrayWriter;
-use crate::row::binary_map::FlussMap;
-use crate::row::datum::{Date, Datum, Time, TimestampLtz, TimestampNtz};
-use crate::row::{Decimal, FlussArray, GenericRow, InternalRow};
-use arrow::array::{
-    Array, AsArray, BinaryArray, BooleanArray, Date32Array, Decimal128Array, FixedSizeBinaryArray,
-    Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, ListArray, MapArray,
-    RecordBatch, StringArray, StructArray, Time32MillisecondArray, Time32SecondArray,
-    Time64MicrosecondArray, Time64NanosecondArray, TimestampMicrosecondArray,
-    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
-};
-use arrow::datatypes::{
-    DataType as ArrowDataType, Date32Type, Decimal128Type, Float32Type, Float64Type, Int8Type,
-    Int16Type, Int32Type, Int64Type, Time32MillisecondType, Time32SecondType,
-    Time64MicrosecondType, Time64NanosecondType, TimeUnit, TimestampMicrosecondType,
-    TimestampMillisecondType, TimestampNanosecondType, TimestampSecondType,
-};
+use crate::row::column_vector::{TypedBatch, TypedColumn};
+use crate::row::columnar::{ColumnarArray, ColumnarMap};
+use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz};
+use crate::row::view::{ArrayView, MapView, RowView};
+use crate::row::{DataGetters, Decimal, InternalRow};
+use arrow::array::{Array, RecordBatch};
 use std::sync::Arc;
 
-#[derive(Clone)]
+/// Cursor over one row of a typed Arrow column-vector batch. Cheap to clone;
+/// advance via [`set_row_id`](Self::set_row_id).
+#[derive(Debug, Clone)]
 pub struct ColumnarRow {
-    record_batch: Arc<RecordBatch>,
-    row_type: Arc<RowType>,
+    batch: Arc<TypedBatch>,
     row_id: usize,
-    fluss_row_type: Option<Arc<RowType>>,
-    row_column_indices: Arc<[usize]>,
-    row_caches: Box<[std::sync::OnceLock<GenericRow<'static>>]>,
-}
-
-pub(crate) fn fluss_row_column_indices(row_type: &RowType) -> Arc<[usize]> {
-    row_type
-        .fields()
-        .iter()
-        .enumerate()
-        .filter_map(|(i, f)| matches!(f.data_type, DataType::Row(_)).then_some(i))
-        .collect()
-}
-
-pub(crate) fn arrow_row_column_indices(batch: &RecordBatch) -> Arc<[usize]> {
-    batch
-        .columns()
-        .iter()
-        .enumerate()
-        .filter_map(|(i, c)| matches!(c.data_type(), ArrowDataType::Struct(_)).then_some(i))
-        .collect()
-}
-
-fn make_row_caches(indices: &[usize]) -> Box<[std::sync::OnceLock<GenericRow<'static>>]> {
-    indices.iter().map(|_| std::sync::OnceLock::new()).collect()
 }
 
 impl ColumnarRow {
+    /// Primary constructor — caller already has a typed batch.
+    pub(crate) fn from_typed_batch(batch: Arc<TypedBatch>, row_id: usize) -> Self {
+        Self { batch, row_id }
+    }
+
+    /// Builds the typed batch in-line from a `RecordBatch` plus [`RowType`].
+    /// `fluss_row_type`, when provided, overrides `row_type`. If both are
+    /// empty, the Fluss types are inferred from the Arrow schema.
     pub fn new(
-        batch: Arc<RecordBatch>,
+        record_batch: Arc<RecordBatch>,
         row_type: Arc<RowType>,
         row_id: usize,
         fluss_row_type: Option<Arc<RowType>>,
-    ) -> Self {
-        let row_column_indices = match &fluss_row_type {
-            Some(rt) => fluss_row_column_indices(rt),
-            None => arrow_row_column_indices(&batch),
-        };
-        Self::with_indices(batch, row_type, row_id, fluss_row_type, row_column_indices)
-    }
-
-    pub(crate) fn with_indices(
-        batch: Arc<RecordBatch>,
-        row_type: Arc<RowType>,
-        row_id: usize,
-        fluss_row_type: Option<Arc<RowType>>,
-        row_column_indices: Arc<[usize]>,
-    ) -> Self {
-        let row_caches = make_row_caches(&row_column_indices);
-        ColumnarRow {
-            record_batch: batch,
-            row_type,
-            row_id,
-            fluss_row_type,
-            row_column_indices,
-            row_caches,
-        }
-    }
-
-    pub fn fluss_row_type(&self) -> Option<&Arc<RowType>> {
-        self.fluss_row_type.as_ref()
+    ) -> Result<Self> {
+        let schema = pick_schema(&record_batch, &row_type, fluss_row_type.as_deref())?;
+        let typed = TypedBatch::build(&record_batch, &schema)?;
+        Ok(Self::from_typed_batch(Arc::new(typed), row_id))
     }
 
     pub fn set_row_id(&mut self, row_id: usize) {
         self.row_id = row_id;
-        for lock in self.row_caches.iter_mut() {
-            *lock = std::sync::OnceLock::new();
-        }
     }
 
     pub fn get_row_id(&self) -> usize {
         self.row_id
     }
 
+    /// Returns the source `RecordBatch`. Panics on a nested cursor (returned
+    /// from [`DataGetters::get_row`]) — those have no batch of their own.
     pub fn get_record_batch(&self) -> &RecordBatch {
-        &self.record_batch
+        self.batch.record_batch.as_ref().expect(
+            "get_record_batch called on a nested ColumnarRow; only the outer scan-level \
+             cursor carries a RecordBatch",
+        )
     }
 
-    fn column(&self, pos: usize) -> Result<&Arc<dyn Array>> {
-        self.record_batch
-            .columns()
-            .get(pos)
-            .ok_or_else(|| IllegalArgument {
-                message: format!(
-                    "column index {pos} out of bounds (batch has {} columns)",
-                    self.record_batch.num_columns()
-                ),
-            })
+    fn column(&self, pos: usize) -> Result<&TypedColumn> {
+        self.batch.columns.get(pos).ok_or_else(|| IllegalArgument {
+            message: format!(
+                "column index {pos} out of bounds (batch has {} columns)",
+                self.batch.columns.len()
+            ),
+        })
+    }
+}
+
+fn pick_schema(
+    record_batch: &RecordBatch,
+    row_type: &Arc<RowType>,
+    fluss_row_type: Option<&RowType>,
+) -> Result<Arc<RowType>> {
+    if let Some(fluss) = fluss_row_type {
+        return Ok(Arc::new(fluss.clone()));
+    }
+    if !row_type.fields().is_empty() {
+        return Ok(row_type.clone());
+    }
+    let mut fields = Vec::with_capacity(record_batch.num_columns());
+    for arrow_field in record_batch.schema().fields() {
+        let dt = from_arrow_field(arrow_field)?;
+        fields.push(DataField::new(arrow_field.name(), dt, None));
+    }
+    Ok(Arc::new(RowType::new(fields)))
+}
+
+impl InternalRow for ColumnarRow {
+    fn get_field_count(&self) -> usize {
+        self.batch.columns.len()
+    }
+}
+
+impl DataGetters for ColumnarRow {
+    fn is_null_at(&self, pos: usize) -> Result<bool> {
+        Ok(self.column(pos)?.is_null_at(self.row_id))
     }
 
-    /// Generic helper to read timestamp from Arrow, handling all TimeUnit conversions.
-    /// Like Java, the precision parameter is ignored - conversion is determined by Arrow TimeUnit.
-    fn read_timestamp_from_arrow<T>(
-        &self,
-        pos: usize,
-        _precision: u32,
-        construct_compact: impl FnOnce(i64) -> T,
-        construct_with_nanos: impl FnOnce(i64, i32) -> Result<T>,
-    ) -> Result<T> {
+    fn get_boolean(&self, pos: usize) -> Result<bool> {
+        self.column(pos)?.get_boolean(self.row_id)
+    }
+    fn get_byte(&self, pos: usize) -> Result<i8> {
+        self.column(pos)?.get_byte(self.row_id)
+    }
+    fn get_short(&self, pos: usize) -> Result<i16> {
+        self.column(pos)?.get_short(self.row_id)
+    }
+    fn get_int(&self, pos: usize) -> Result<i32> {
+        self.column(pos)?.get_int(self.row_id)
+    }
+    fn get_long(&self, pos: usize) -> Result<i64> {
+        self.column(pos)?.get_long(self.row_id)
+    }
+    fn get_float(&self, pos: usize) -> Result<f32> {
+        self.column(pos)?.get_float(self.row_id)
+    }
+    fn get_double(&self, pos: usize) -> Result<f64> {
+        self.column(pos)?.get_double(self.row_id)
+    }
+
+    fn get_char(&self, pos: usize, _length: usize) -> Result<&str> {
+        self.column(pos)?.get_char(self.row_id)
+    }
+    fn get_string(&self, pos: usize) -> Result<&str> {
+        self.column(pos)?.get_string(self.row_id)
+    }
+
+    fn get_decimal(&self, pos: usize, precision: usize, scale: usize) -> Result<Decimal> {
+        self.column(pos)?
+            .get_decimal(self.row_id, precision as u32, scale as u32)
+    }
+
+    fn get_date(&self, pos: usize) -> Result<Date> {
+        self.column(pos)?.get_date(self.row_id)
+    }
+    fn get_time(&self, pos: usize) -> Result<Time> {
+        self.column(pos)?.get_time(self.row_id)
+    }
+    fn get_timestamp_ntz(&self, pos: usize, _precision: u32) -> Result<TimestampNtz> {
+        self.column(pos)?.get_timestamp_ntz(self.row_id)
+    }
+    fn get_timestamp_ltz(&self, pos: usize, _precision: u32) -> Result<TimestampLtz> {
+        self.column(pos)?.get_timestamp_ltz(self.row_id)
+    }
+
+    fn get_binary(&self, pos: usize, _length: usize) -> Result<&[u8]> {
+        self.column(pos)?.get_binary(self.row_id)
+    }
+    fn get_bytes(&self, pos: usize) -> Result<&[u8]> {
+        self.column(pos)?.get_bytes(self.row_id)
+    }
+
+    fn get_array(&self, pos: usize) -> Result<ArrayView<'_>> {
         let column = self.column(pos)?;
-
-        // Read value and time unit based on the actual Arrow timestamp type
-        let (value, time_unit) = match column.data_type() {
-            ArrowDataType::Timestamp(TimeUnit::Second, _) => (
-                column
-                    .as_primitive_opt::<TimestampSecondType>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!("expected TimestampSecondArray at position {pos}"),
-                    })?
-                    .value(self.row_id),
-                TimeUnit::Second,
-            ),
-            ArrowDataType::Timestamp(TimeUnit::Millisecond, _) => (
-                column
-                    .as_primitive_opt::<TimestampMillisecondType>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!("expected TimestampMillisecondArray at position {pos}"),
-                    })?
-                    .value(self.row_id),
-                TimeUnit::Millisecond,
-            ),
-            ArrowDataType::Timestamp(TimeUnit::Microsecond, _) => (
-                column
-                    .as_primitive_opt::<TimestampMicrosecondType>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!("expected TimestampMicrosecondArray at position {pos}"),
-                    })?
-                    .value(self.row_id),
-                TimeUnit::Microsecond,
-            ),
-            ArrowDataType::Timestamp(TimeUnit::Nanosecond, _) => (
-                column
-                    .as_primitive_opt::<TimestampNanosecondType>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!("expected TimestampNanosecondArray at position {pos}"),
-                    })?
-                    .value(self.row_id),
-                TimeUnit::Nanosecond,
-            ),
-            other => {
-                return Err(IllegalArgument {
-                    message: format!("expected Timestamp column at position {pos}, got {other:?}"),
-                });
+        match column {
+            TypedColumn::Array(list_arr, element) => {
+                let row_id = self.row_id;
+                let start = list_arr.value_offsets()[row_id] as usize;
+                let end = list_arr.value_offsets()[row_id + 1] as usize;
+                Ok(ArrayView::Columnar(ColumnarArray::new(
+                    element.as_ref(),
+                    start,
+                    end - start,
+                )))
             }
-        };
-
-        // Convert based on Arrow TimeUnit
-        let (millis, nanos) = match time_unit {
-            TimeUnit::Second => (value * 1000, 0),
-            TimeUnit::Millisecond => (value, 0),
-            TimeUnit::Microsecond => {
-                // Use Euclidean division so that nanos is always non-negative,
-                // even for timestamps before the Unix epoch.
-                let millis = value.div_euclid(1000);
-                let nanos = (value.rem_euclid(1000) * 1000) as i32;
-                (millis, nanos)
-            }
-            TimeUnit::Nanosecond => {
-                // Use Euclidean division so that nanos is always in [0, 999_999].
-                let millis = value.div_euclid(1_000_000);
-                let nanos = value.rem_euclid(1_000_000) as i32;
-                (millis, nanos)
-            }
-        };
-
-        if nanos == 0 {
-            Ok(construct_compact(millis))
-        } else {
-            construct_with_nanos(millis, nanos)
+            other => Err(IllegalArgument {
+                message: format!("expected ARRAY column at position {pos}, got {other:?}"),
+            }),
         }
     }
 
-    /// Read date value from Arrow Date32Array
-    fn read_date_from_arrow(&self, pos: usize) -> Result<i32> {
-        Ok(self
-            .column(pos)?
-            .as_primitive_opt::<Date32Type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected Date32Array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    /// Read time value from Arrow Time32/Time64 arrays, converting to milliseconds
-    fn read_time_from_arrow(&self, pos: usize) -> Result<i32> {
+    fn get_map(&self, pos: usize) -> Result<MapView<'_>> {
         let column = self.column(pos)?;
-
-        match column.data_type() {
-            ArrowDataType::Time32(TimeUnit::Second) => {
-                let value = column
-                    .as_primitive_opt::<Time32SecondType>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!("expected Time32SecondArray at position {pos}"),
-                    })?
-                    .value(self.row_id);
-                Ok(value * 1000) // Convert seconds to milliseconds
-            }
-            ArrowDataType::Time32(TimeUnit::Millisecond) => Ok(column
-                .as_primitive_opt::<Time32MillisecondType>()
-                .ok_or_else(|| IllegalArgument {
-                    message: format!("expected Time32MillisecondArray at position {pos}"),
-                })?
-                .value(self.row_id)),
-            ArrowDataType::Time64(TimeUnit::Microsecond) => {
-                let value = column
-                    .as_primitive_opt::<Time64MicrosecondType>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!("expected Time64MicrosecondArray at position {pos}"),
-                    })?
-                    .value(self.row_id);
-                Ok((value / 1000) as i32) // Convert microseconds to milliseconds
-            }
-            ArrowDataType::Time64(TimeUnit::Nanosecond) => {
-                let value = column
-                    .as_primitive_opt::<Time64NanosecondType>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!("expected Time64NanosecondArray at position {pos}"),
-                    })?
-                    .value(self.row_id);
-                Ok((value / 1_000_000) as i32) // Convert nanoseconds to milliseconds
+        match column {
+            TypedColumn::Map(map_arr, keys, values) => {
+                let row_id = self.row_id;
+                let start = map_arr.value_offsets()[row_id] as usize;
+                let end = map_arr.value_offsets()[row_id + 1] as usize;
+                Ok(MapView::Columnar(ColumnarMap::new(
+                    keys.as_ref(),
+                    values.as_ref(),
+                    start,
+                    end - start,
+                )))
             }
             other => Err(IllegalArgument {
-                message: format!("expected Time column at position {pos}, got {other:?}"),
+                message: format!("expected MAP column at position {pos}, got {other:?}"),
+            }),
+        }
+    }
+
+    fn get_row(&self, pos: usize) -> Result<RowView<'_>> {
+        let column = self.column(pos)?;
+        match column {
+            TypedColumn::Row(struct_arr, inner_batch) => {
+                if struct_arr.is_null(self.row_id) {
+                    return Err(IllegalArgument {
+                        message: format!(
+                            "get_row called on null ROW cell at position {pos}, row {}; \
+                             check is_null_at({pos}) first",
+                            self.row_id
+                        ),
+                    });
+                }
+                Ok(RowView::Columnar(Self {
+                    batch: Arc::clone(inner_batch),
+                    row_id: self.row_id,
+                }))
+            }
+            other => Err(IllegalArgument {
+                message: format!("expected ROW column at position {pos}, got {other:?}"),
             }),
         }
     }
 }
 
-fn extract_struct_from_array(
-    array: &dyn Array,
-    row_id: usize,
-    row_type: Option<&RowType>,
-) -> Result<GenericRow<'static>> {
-    let sa = array
-        .as_any()
-        .downcast_ref::<StructArray>()
-        .ok_or_else(|| IllegalArgument {
-            message: format!("expected StructArray, got {:?}", array.data_type()),
-        })?;
-    if let Some(rt) = row_type
-        && rt.fields().len() != sa.num_columns()
-    {
-        return Err(IllegalArgument {
-            message: format!(
-                "Fluss RowType has {} fields but Arrow StructArray has {}",
-                rt.fields().len(),
-                sa.num_columns(),
-            ),
-        });
-    }
-    let mut values = Vec::with_capacity(sa.num_columns());
-    for i in 0..sa.num_columns() {
-        let child = sa.column(i);
-        let fluss_type = row_type.map(|rt| &rt.fields()[i].data_type);
-        values.push(arrow_value_to_datum(child.as_ref(), row_id, fluss_type)?);
-    }
-    Ok(GenericRow { values })
-}
-
-fn arrow_value_to_datum(
-    array: &dyn Array,
-    row_id: usize,
-    fluss_type: Option<&DataType>,
-) -> Result<Datum<'static>> {
-    if array.is_null(row_id) {
-        return Ok(Datum::Null);
-    }
-
-    macro_rules! downcast {
-        ($ty:ty) => {
-            array
-                .as_any()
-                .downcast_ref::<$ty>()
-                .ok_or_else(|| IllegalArgument {
-                    message: format!(
-                        "expected {} for arrow type {:?}",
-                        stringify!($ty),
-                        array.data_type()
-                    ),
-                })?
-        };
-    }
-
-    match array.data_type() {
-        ArrowDataType::Boolean => Ok(Datum::Bool(downcast!(BooleanArray).value(row_id))),
-        ArrowDataType::Int8 => Ok(Datum::Int8(downcast!(Int8Array).value(row_id))),
-        ArrowDataType::Int16 => Ok(Datum::Int16(downcast!(Int16Array).value(row_id))),
-        ArrowDataType::Int32 => Ok(Datum::Int32(downcast!(Int32Array).value(row_id))),
-        ArrowDataType::Int64 => Ok(Datum::Int64(downcast!(Int64Array).value(row_id))),
-        ArrowDataType::Float32 => Ok(Datum::Float32(downcast!(Float32Array).value(row_id).into())),
-        ArrowDataType::Float64 => Ok(Datum::Float64(downcast!(Float64Array).value(row_id).into())),
-        ArrowDataType::Utf8 => Ok(Datum::String(std::borrow::Cow::Owned(
-            downcast!(StringArray).value(row_id).to_owned(),
-        ))),
-        ArrowDataType::Binary => Ok(Datum::Blob(std::borrow::Cow::Owned(
-            downcast!(BinaryArray).value(row_id).to_vec(),
-        ))),
-        ArrowDataType::FixedSizeBinary(_) => Ok(Datum::Blob(std::borrow::Cow::Owned(
-            downcast!(FixedSizeBinaryArray).value(row_id).to_vec(),
-        ))),
-        ArrowDataType::Decimal128(p, s) => {
-            let (p, s) = (*p, *s);
-            let i128_val = downcast!(Decimal128Array).value(row_id);
-            Ok(Datum::Decimal(Decimal::from_arrow_decimal128(
-                i128_val, s as i64, p as u32, s as u32,
-            )?))
-        }
-        ArrowDataType::Date32 => Ok(Datum::Date(Date::new(downcast!(Date32Array).value(row_id)))),
-        ArrowDataType::Time32(TimeUnit::Second) => Ok(Datum::Time(Time::new(
-            downcast!(Time32SecondArray).value(row_id) * 1000,
-        ))),
-        ArrowDataType::Time32(TimeUnit::Millisecond) => Ok(Datum::Time(Time::new(
-            downcast!(Time32MillisecondArray).value(row_id),
-        ))),
-        ArrowDataType::Time64(TimeUnit::Microsecond) => Ok(Datum::Time(Time::new(
-            (downcast!(Time64MicrosecondArray).value(row_id) / 1000) as i32,
-        ))),
-        ArrowDataType::Time64(TimeUnit::Nanosecond) => Ok(Datum::Time(Time::new(
-            (downcast!(Time64NanosecondArray).value(row_id) / 1_000_000) as i32,
-        ))),
-        ArrowDataType::Timestamp(time_unit, _tz) => {
-            let value: i64 = match time_unit {
-                TimeUnit::Second => downcast!(TimestampSecondArray).value(row_id),
-                TimeUnit::Millisecond => downcast!(TimestampMillisecondArray).value(row_id),
-                TimeUnit::Microsecond => downcast!(TimestampMicrosecondArray).value(row_id),
-                TimeUnit::Nanosecond => downcast!(TimestampNanosecondArray).value(row_id),
-            };
-            let (millis, nanos) = match time_unit {
-                TimeUnit::Second => (value * 1000, 0i32),
-                TimeUnit::Millisecond => (value, 0i32),
-                TimeUnit::Microsecond => {
-                    let millis = value.div_euclid(1000);
-                    let nanos = (value.rem_euclid(1000) * 1000) as i32;
-                    (millis, nanos)
-                }
-                TimeUnit::Nanosecond => {
-                    let millis = value.div_euclid(1_000_000);
-                    let nanos = value.rem_euclid(1_000_000) as i32;
-                    (millis, nanos)
-                }
-            };
-            // TIMESTAMP and TIMESTAMP_LTZ both map to `Timestamp(unit, None)` in Arrow.
-            let is_ltz = matches!(fluss_type, Some(DataType::TimestampLTz(_)));
-            if is_ltz {
-                if nanos == 0 {
-                    Ok(Datum::TimestampLtz(TimestampLtz::new(millis)))
-                } else {
-                    Ok(Datum::TimestampLtz(TimestampLtz::from_millis_nanos(
-                        millis, nanos,
-                    )?))
-                }
-            } else if nanos == 0 {
-                Ok(Datum::TimestampNtz(TimestampNtz::new(millis)))
-            } else {
-                Ok(Datum::TimestampNtz(TimestampNtz::from_millis_nanos(
-                    millis, nanos,
-                )?))
-            }
-        }
-        ArrowDataType::Struct(_) => {
-            let nested_row_type = fluss_type.and_then(|t| match t {
-                DataType::Row(rt) => Some(rt),
-                _ => None,
-            });
-            let nested = extract_struct_from_array(array, row_id, nested_row_type)?;
-            Ok(Datum::Row(Box::new(nested)))
-        }
-        ArrowDataType::List(field) => {
-            let list_arr = downcast!(ListArray);
-            let values = list_arr.value(row_id);
-            // Infer via from_arrow_field so the inferred element type
-            // matches what `arrow_map_entry_to_fluss_map` / strict `==`
-            // expect when there's no upstream Fluss schema.
-            let element_fluss_type = match fluss_type {
-                Some(DataType::Array(at)) => at.get_element_type().clone(),
-                _ => from_arrow_field(field)?,
-            };
-            let mut writer = FlussArrayWriter::new(values.len(), &element_fluss_type);
-            write_arrow_values_to_fluss_array(&*values, &element_fluss_type, &mut writer)?;
-            Ok(Datum::Array(writer.complete()?))
-        }
-        ArrowDataType::Map(entries_field, _) => {
-            let map_arr = downcast!(MapArray);
-            let entries = map_arr.value(row_id);
-            let (key_type, value_type) = match fluss_type {
-                Some(DataType::Map(m)) => (m.key_type().clone(), m.value_type().clone()),
-                _ => {
-                    let fields = match entries_field.data_type() {
-                        ArrowDataType::Struct(f) => f,
-                        other => {
-                            return Err(IllegalArgument {
-                                message: format!("expected Struct for Map entries, got {other:?}"),
-                            });
-                        }
-                    };
-                    if fields.len() != 2 {
-                        return Err(IllegalArgument {
-                            message: format!(
-                                "Map entries Struct must have 2 fields, got {}",
-                                fields.len()
-                            ),
-                        });
-                    }
-                    (from_arrow_field(&fields[0])?, from_arrow_field(&fields[1])?)
-                }
-            };
-            Ok(Datum::Map(arrow_map_entry_to_fluss_map(
-                &entries,
-                &key_type,
-                &value_type,
-            )?))
-        }
-        other => Err(IllegalArgument {
-            message: format!("unsupported Arrow data type for nested row extraction: {other:?}"),
-        }),
-    }
-}
-
-impl InternalRow for ColumnarRow {
-    fn get_field_count(&self) -> usize {
-        self.record_batch.num_columns()
-    }
-
-    fn is_null_at(&self, pos: usize) -> Result<bool> {
-        Ok(self.column(pos)?.is_null(self.row_id))
-    }
-
-    fn get_boolean(&self, pos: usize) -> Result<bool> {
-        Ok(self
-            .column(pos)?
-            .as_boolean_opt()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected boolean array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_byte(&self, pos: usize) -> Result<i8> {
-        Ok(self
-            .column(pos)?
-            .as_primitive_opt::<Int8Type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected byte array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_short(&self, pos: usize) -> Result<i16> {
-        Ok(self
-            .column(pos)?
-            .as_primitive_opt::<Int16Type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected short array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_int(&self, pos: usize) -> Result<i32> {
-        Ok(self
-            .column(pos)?
-            .as_primitive_opt::<Int32Type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected int array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_long(&self, pos: usize) -> Result<i64> {
-        Ok(self
-            .column(pos)?
-            .as_primitive_opt::<Int64Type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected long array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_float(&self, pos: usize) -> Result<f32> {
-        Ok(self
-            .column(pos)?
-            .as_primitive_opt::<Float32Type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected float32 array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_double(&self, pos: usize) -> Result<f64> {
-        Ok(self
-            .column(pos)?
-            .as_primitive_opt::<Float64Type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected float64 array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_char(&self, pos: usize, _length: usize) -> Result<&str> {
-        Ok(self
-            .column(pos)?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected String array for char type at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_string(&self, pos: usize) -> Result<&str> {
-        Ok(self
-            .column(pos)?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected String array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_decimal(&self, pos: usize, precision: usize, scale: usize) -> Result<Decimal> {
-        let column = self.column(pos)?;
-        let array = column
-            .as_primitive_opt::<Decimal128Type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!(
-                    "expected Decimal128Array at column {pos}, found: {:?}",
-                    column.data_type()
-                ),
-            })?;
-
-        // Contract: caller must check is_null_at() before calling get_decimal.
-        debug_assert!(
-            !array.is_null(self.row_id),
-            "get_decimal called on null value at pos {} row {}",
-            pos,
-            self.row_id
-        );
-
-        let arrow_scale = match column.data_type() {
-            ArrowDataType::Decimal128(_p, s) => *s as i64,
-            dt => {
-                return Err(IllegalArgument {
-                    message: format!(
-                        "expected Decimal128 data type at column {pos}, found: {dt:?}"
-                    ),
-                });
-            }
-        };
-
-        Decimal::from_arrow_decimal128(
-            array.value(self.row_id),
-            arrow_scale,
-            precision as u32,
-            scale as u32,
-        )
-    }
-
-    fn get_date(&self, pos: usize) -> Result<Date> {
-        Ok(Date::new(self.read_date_from_arrow(pos)?))
-    }
-
-    fn get_time(&self, pos: usize) -> Result<Time> {
-        Ok(Time::new(self.read_time_from_arrow(pos)?))
-    }
-
-    fn get_timestamp_ntz(&self, pos: usize, precision: u32) -> Result<TimestampNtz> {
-        self.read_timestamp_from_arrow(
-            pos,
-            precision,
-            TimestampNtz::new,
-            TimestampNtz::from_millis_nanos,
-        )
-    }
-
-    fn get_timestamp_ltz(&self, pos: usize, precision: u32) -> Result<TimestampLtz> {
-        self.read_timestamp_from_arrow(
-            pos,
-            precision,
-            TimestampLtz::new,
-            TimestampLtz::from_millis_nanos,
-        )
-    }
-
-    fn get_binary(&self, pos: usize, _length: usize) -> Result<&[u8]> {
-        Ok(self
-            .column(pos)?
-            .as_fixed_size_binary_opt()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected binary array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_bytes(&self, pos: usize) -> Result<&[u8]> {
-        Ok(self
-            .column(pos)?
-            .as_any()
-            .downcast_ref::<BinaryArray>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!("expected bytes array at position {pos}"),
-            })?
-            .value(self.row_id))
-    }
-
-    fn get_array(&self, pos: usize) -> Result<FlussArray> {
-        let expected_type = self.row_type.fields()[pos].data_type();
-        let element_fluss_type = match expected_type {
-            DataType::Array(a) => a.get_element_type(),
-            _ => {
-                return Err(IllegalArgument {
-                    message: format!(
-                        "expected Array type at position {pos}, got {expected_type:?}"
-                    ),
-                });
-            }
-        };
-
-        let column = self.column(pos)?;
-        match column.data_type() {
-            ArrowDataType::List(_) => {}
-            other => {
-                return Err(IllegalArgument {
-                    message: format!("expected List array at position {pos}, got {other:?}"),
-                });
-            }
-        }
-
-        // `to_arrow_type` is lossy (e.g. TIMESTAMP_LTZ → plain Arrow Timestamp);
-        // trust the Fluss schema and let the per-element conversion below catch
-        // real shape mismatches.
-
-        let list_arr = column
-            .as_any()
-            .downcast_ref::<ListArray>()
-            .expect("data_type matched List but downcast failed; arrow-rs invariant violated");
-        let values = list_arr.value(self.row_id);
-        let mut writer = FlussArrayWriter::new(values.len(), element_fluss_type);
-        write_arrow_values_to_fluss_array(&*values, element_fluss_type, &mut writer)?;
-        writer.complete()
-    }
-
-    fn get_map(&self, pos: usize) -> Result<FlussMap> {
-        let expected_type = self.row_type.fields()[pos].data_type();
-        let map_type = match expected_type {
-            DataType::Map(m) => m,
-            _ => {
-                return Err(IllegalArgument {
-                    message: format!("expected Map type at position {pos}, got {expected_type:?}"),
-                });
-            }
-        };
-
-        let column = self.column(pos)?;
-        let map_arr =
-            column
-                .as_any()
-                .downcast_ref::<MapArray>()
-                .ok_or_else(|| IllegalArgument {
-                    message: format!(
-                        "expected Map array at position {pos}, got {:?}",
-                        column.data_type()
-                    ),
-                })?;
-
-        arrow_map_entry_to_fluss_map(
-            &map_arr.value(self.row_id),
-            map_type.key_type(),
-            map_type.value_type(),
-        )
-    }
-
-    fn get_row(&self, pos: usize) -> Result<&GenericRow<'_>> {
-        let cache_idx = self
-            .row_column_indices
-            .iter()
-            .position(|&i| i == pos)
-            .ok_or_else(|| IllegalArgument {
-                message: format!("get_row called on non-ROW column at position {pos}"),
-            })?;
-        let column = self.record_batch.column(pos);
-        // Children of a null parent may carry stale bytes; caller must
-        // check is_null_at first rather than rely on what we'd read.
-        if column.is_null(self.row_id) {
-            return Err(IllegalArgument {
-                message: format!(
-                    "get_row called on null ROW cell at position {pos}, row {}; \
-                     check is_null_at({pos}) first",
-                    self.row_id
-                ),
-            });
-        }
-        let lock = &self.row_caches[cache_idx];
-        if let Some(row) = lock.get() {
-            return Ok(row);
-        }
-        let nested_row_type = self.fluss_row_type.as_ref().and_then(|rt| {
-            rt.fields().get(pos).and_then(|f| match &f.data_type {
-                DataType::Row(inner) => Some(inner),
-                _ => None,
-            })
-        });
-        let extracted = extract_struct_from_array(column.as_ref(), self.row_id, nested_row_type)?;
-        Ok(lock.get_or_init(|| extracted))
-    }
-}
-
-#[inline]
-fn arrow_map_entry_to_fluss_map(
-    struct_arr: &arrow::array::StructArray,
-    key_type: &DataType,
-    value_type: &DataType,
-) -> Result<FlussMap> {
-    let fields = match struct_arr.data_type() {
-        ArrowDataType::Struct(f) => f,
-        other => {
-            return Err(IllegalArgument {
-                message: format!("expected Struct for Map entries, got {other:?}"),
-            });
-        }
-    };
-    if fields.len() != 2 {
-        return Err(IllegalArgument {
-            message: format!(
-                "Expected 2 columns in Map entries struct, got {}",
-                fields.len()
-            ),
-        });
-    }
-
-    // `to_arrow_type` is lossy (e.g. TIMESTAMP_LTZ → plain Arrow Timestamp);
-    // trust the Fluss schema and let the per-element conversion below catch
-    // real shape mismatches.
-
-    let keys_arrow = struct_arr.column(0);
-    let values_arrow = struct_arr.column(1);
-
-    let len = keys_arrow.len();
-
-    // Convert Arrow keys → FlussArray
-    let mut key_writer = FlussArrayWriter::new(len, key_type);
-    write_arrow_values_to_fluss_array(&**keys_arrow, key_type, &mut key_writer)?;
-    let key_array = key_writer.complete()?;
-
-    // Convert Arrow values → FlussArray
-    let mut value_writer = FlussArrayWriter::new(len, value_type);
-    write_arrow_values_to_fluss_array(&**values_arrow, value_type, &mut value_writer)?;
-    let value_array = value_writer.complete()?;
-
-    FlussMap::from_arrays(&key_array, &value_array, key_type, value_type)
-}
-
-/// Downcast to a primitive Arrow array type, then loop with null checks calling a writer method.
-macro_rules! write_primitive_elements {
-    ($values:expr, $arrow_type:ty, $element_type:expr, $writer:expr, $write_method:ident) => {{
-        let arr = $values
-            .as_primitive_opt::<$arrow_type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!(
-                    "expected {} for {:?} element",
-                    stringify!($arrow_type),
-                    $element_type
-                ),
-            })?;
-        for i in 0..arr.len() {
-            if arr.is_null(i) {
-                $writer.set_null_at(i);
-            } else {
-                $writer.$write_method(i, arr.value(i));
-            }
-        }
-    }};
-}
-
-/// Downcast via `downcast_ref`, then loop with null checks calling a writer method.
-macro_rules! write_downcast_elements {
-    ($values:expr, $array_type:ty, $element_type:expr, $writer:expr, $write_method:ident) => {{
-        let arr = $values
-            .as_any()
-            .downcast_ref::<$array_type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!(
-                    "expected {} for {:?} element",
-                    stringify!($array_type),
-                    $element_type
-                ),
-            })?;
-        for i in 0..arr.len() {
-            if arr.is_null(i) {
-                $writer.set_null_at(i);
-            } else {
-                $writer.$write_method(i, arr.value(i));
-            }
-        }
-    }};
-}
-
-/// Downcast via `downcast_ref` to a List array type, then loop with null checks.
-macro_rules! write_list_elements {
-    ($values:expr, $list_array_type:ty, $len:expr, $element_type:expr, $writer:expr) => {{
-        let arr = $values
-            .as_any()
-            .downcast_ref::<$list_array_type>()
-            .ok_or_else(|| IllegalArgument {
-                message: format!(
-                    "expected {} for {:?} element",
-                    stringify!($list_array_type),
-                    $element_type
-                ),
-            })?;
-        let nested_element_type = match $element_type {
-            DataType::Array(a) => a.get_element_type(),
-            _ => unreachable!("Expected Array type for write_list_elements"),
-        };
-        for i in 0..$len {
-            if arr.is_null(i) {
-                $writer.set_null_at(i);
-            } else {
-                let nested_values = arr.value(i);
-                let mut nested_writer =
-                    FlussArrayWriter::new(nested_values.len(), &nested_element_type);
-                write_arrow_values_to_fluss_array(
-                    &*nested_values,
-                    &nested_element_type,
-                    &mut nested_writer,
-                )?;
-                let nested_array = nested_writer.complete()?;
-                $writer.write_array(i, &nested_array);
-            }
-        }
-    }};
-}
-
-/// Converts all elements of an Arrow array into a `FlussArrayWriter`, downcasting
-/// the Arrow array once per call rather than per element.
-fn write_arrow_values_to_fluss_array(
-    values: &dyn Array,
-    element_type: &DataType,
-    writer: &mut FlussArrayWriter,
-) -> Result<()> {
-    let len = values.len();
-
-    match element_type {
-        DataType::Boolean(_) => {
-            write_downcast_elements!(values, BooleanArray, element_type, writer, write_boolean)
-        }
-        DataType::TinyInt(_) => {
-            write_primitive_elements!(values, Int8Type, element_type, writer, write_byte)
-        }
-        DataType::SmallInt(_) => {
-            write_primitive_elements!(values, Int16Type, element_type, writer, write_short)
-        }
-        DataType::Int(_) => {
-            write_primitive_elements!(values, Int32Type, element_type, writer, write_int)
-        }
-        DataType::BigInt(_) => {
-            write_primitive_elements!(values, Int64Type, element_type, writer, write_long)
-        }
-        DataType::Float(_) => {
-            write_primitive_elements!(values, Float32Type, element_type, writer, write_float)
-        }
-        DataType::Double(_) => {
-            write_primitive_elements!(values, Float64Type, element_type, writer, write_double)
-        }
-        DataType::Char(_) | DataType::String(_) => {
-            write_downcast_elements!(values, StringArray, element_type, writer, write_string)
-        }
-        DataType::Binary(_) => {
-            write_downcast_elements!(
-                values,
-                FixedSizeBinaryArray,
-                element_type,
-                writer,
-                write_binary_bytes
-            )
-        }
-        DataType::Bytes(_) => {
-            write_downcast_elements!(
-                values,
-                BinaryArray,
-                element_type,
-                writer,
-                write_binary_bytes
-            )
-        }
-        DataType::Decimal(dt) => {
-            let arr =
-                values
-                    .as_primitive_opt::<Decimal128Type>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!("expected Decimal128Array for {element_type:?} element"),
-                    })?;
-            let arrow_scale = match values.data_type() {
-                ArrowDataType::Decimal128(_p, s) => *s as i64,
-                other => {
-                    return Err(IllegalArgument {
-                        message: format!(
-                            "expected Decimal128 data type for {element_type:?} element, got {other:?}"
-                        ),
-                    });
-                }
-            };
-            let precision = dt.precision();
-            let scale = dt.scale();
-            for i in 0..len {
-                if arr.is_null(i) {
-                    writer.set_null_at(i);
-                } else {
-                    let d = Decimal::from_arrow_decimal128(
-                        arr.value(i),
-                        arrow_scale,
-                        precision,
-                        scale,
-                    )?;
-                    writer.write_decimal(i, &d, precision);
-                }
-            }
-        }
-        DataType::Date(_) => {
-            let arr = values
-                .as_primitive_opt::<Date32Type>()
-                .ok_or_else(|| IllegalArgument {
-                    message: format!("expected Date32Array for {element_type:?} element"),
-                })?;
-            for i in 0..len {
-                if arr.is_null(i) {
-                    writer.set_null_at(i);
-                } else {
-                    writer.write_date(i, Date::new(arr.value(i)));
-                }
-            }
-        }
-        DataType::Time(_) => {
-            write_time_elements(values, element_type, writer)?;
-        }
-        DataType::Timestamp(ts_type) => {
-            write_timestamp_elements(
-                values,
-                element_type,
-                writer,
-                ts_type.precision(),
-                TimestampNtz::new,
-                TimestampNtz::from_millis_nanos,
-                |w, i, ts, p| w.write_timestamp_ntz(i, &ts, p),
-            )?;
-        }
-        DataType::TimestampLTz(ts_type) => {
-            write_timestamp_elements(
-                values,
-                element_type,
-                writer,
-                ts_type.precision(),
-                TimestampLtz::new,
-                TimestampLtz::from_millis_nanos,
-                |w, i, ts, p| w.write_timestamp_ltz(i, &ts, p),
-            )?;
-        }
-        DataType::Array(_) => {
-            if values.as_any().is::<ListArray>() {
-                write_list_elements!(values, ListArray, len, element_type, writer);
-            } else {
-                return Err(IllegalArgument {
-                    message: format!(
-                        "expected ListArray for {element_type:?} element, got {:?}",
-                        values.data_type()
-                    ),
-                });
-            }
-        }
-        DataType::Map(_) => {
-            let map_arr =
-                values
-                    .as_any()
-                    .downcast_ref::<MapArray>()
-                    .ok_or_else(|| IllegalArgument {
-                        message: format!(
-                            "Expected MapArray for {element_type:?} element, got {:?}",
-                            values.data_type()
-                        ),
-                    })?;
-            for i in 0..len {
-                if map_arr.is_null(i) {
-                    writer.set_null_at(i);
-                } else {
-                    let expected_map_type = match element_type {
-                        DataType::Map(m) => m,
-                        _ => unreachable!("Expected Map type for Map variant"),
-                    };
-                    let fluss_map = arrow_map_entry_to_fluss_map(
-                        &map_arr.value(i),
-                        expected_map_type.key_type(),
-                        expected_map_type.value_type(),
-                    )?;
-                    writer.write_map(i, &fluss_map);
-                }
-            }
-        }
-        DataType::Row(row_type) => {
-            let struct_arr = values
-                .as_any()
-                .downcast_ref::<StructArray>()
-                .ok_or_else(|| IllegalArgument {
-                    message: format!(
-                        "expected StructArray for {element_type:?} element, got {:?}",
-                        values.data_type()
-                    ),
-                })?;
-            for i in 0..len {
-                if struct_arr.is_null(i) {
-                    writer.set_null_at(i);
-                } else {
-                    let nested = extract_struct_from_array(struct_arr, i, Some(row_type))?;
-                    writer.write_row(i, &nested)?;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn write_time_elements(
-    values: &dyn Array,
-    element_type: &DataType,
-    writer: &mut FlussArrayWriter,
-) -> Result<()> {
-    macro_rules! process_time {
-        ($arrow_type:ty, $to_millis:expr) => {{
-            let arr = values
-                .as_primitive_opt::<$arrow_type>()
-                .ok_or_else(|| IllegalArgument {
-                    message: format!(
-                        "expected {} for {:?} element",
-                        stringify!($arrow_type),
-                        element_type
-                    ),
-                })?;
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    writer.set_null_at(i);
-                } else {
-                    let to_millis_fn = $to_millis;
-                    writer.write_time(i, Time::new(to_millis_fn(arr.value(i))));
-                }
-            }
-        }};
-    }
-
-    match values.data_type() {
-        ArrowDataType::Time32(TimeUnit::Second) => {
-            process_time!(Time32SecondType, |v: i32| v * 1000);
-        }
-        ArrowDataType::Time32(TimeUnit::Millisecond) => {
-            process_time!(Time32MillisecondType, |v: i32| v);
-        }
-        ArrowDataType::Time64(TimeUnit::Microsecond) => {
-            process_time!(Time64MicrosecondType, |v: i64| (v / 1000) as i32);
-        }
-        ArrowDataType::Time64(TimeUnit::Nanosecond) => {
-            process_time!(Time64NanosecondType, |v: i64| (v / 1_000_000) as i32);
-        }
-        other => {
-            return Err(IllegalArgument {
-                message: format!(
-                    "expected Time column for {element_type:?} element, got {other:?}"
-                ),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn convert_timestamp_raw(raw: i64, unit: &TimeUnit) -> (i64, i32) {
-    match unit {
-        TimeUnit::Second => (raw * 1000, 0),
-        TimeUnit::Millisecond => (raw, 0),
-        TimeUnit::Microsecond => {
-            let millis = raw.div_euclid(1000);
-            let nanos = (raw.rem_euclid(1000) * 1000) as i32;
-            (millis, nanos)
-        }
-        TimeUnit::Nanosecond => {
-            let millis = raw.div_euclid(1_000_000);
-            let nanos = raw.rem_euclid(1_000_000) as i32;
-            (millis, nanos)
-        }
-    }
-}
-
-fn write_timestamp_elements<T>(
-    values: &dyn Array,
-    element_type: &DataType,
-    writer: &mut FlussArrayWriter,
-    precision: u32,
-    construct_compact: impl Fn(i64) -> T,
-    construct_with_nanos: impl Fn(i64, i32) -> Result<T>,
-    write_fn: impl Fn(&mut FlussArrayWriter, usize, T, u32),
-) -> Result<()> {
-    let unit = match values.data_type() {
-        ArrowDataType::Timestamp(unit, _) => unit,
-        other => {
-            return Err(IllegalArgument {
-                message: format!(
-                    "expected Timestamp column for {element_type:?} element, got {other:?}"
-                ),
-            });
-        }
-    };
-
-    macro_rules! process_ts {
-        ($arrow_type:ty) => {{
-            let arr = values
-                .as_primitive_opt::<$arrow_type>()
-                .ok_or_else(|| IllegalArgument {
-                    message: format!(
-                        "expected {} for {:?} element",
-                        stringify!($arrow_type),
-                        element_type
-                    ),
-                })?;
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    writer.set_null_at(i);
-                    continue;
-                }
-                let (millis, nanos) = convert_timestamp_raw(arr.value(i), unit);
-                let ts = if nanos == 0 {
-                    construct_compact(millis)
-                } else {
-                    construct_with_nanos(millis, nanos)?
-                };
-                write_fn(writer, i, ts, precision);
-            }
-        }};
-    }
-
-    match unit {
-        TimeUnit::Second => process_ts!(TimestampSecondType),
-        TimeUnit::Millisecond => process_ts!(TimestampMillisecondType),
-        TimeUnit::Microsecond => process_ts!(TimestampMicrosecondType),
-        TimeUnit::Nanosecond => process_ts!(TimestampNanosecondType),
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metadata::{DataField, RowType};
+    use crate::metadata::{ArrayType, DataField, DataType, DataTypes, IntType, RowType};
+    use crate::row::{InternalArray, InternalMap};
     use arrow::array::{
-        ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Float32Array, Float64Array,
-        Int8Array, Int16Array, Int32Array, Int32Builder, Int64Array, ListBuilder, StringArray,
-        StructArray, UInt32Builder,
+        Array, ArrayRef, BinaryArray, BooleanArray, Decimal128Array, Float32Array, Float64Array,
+        Int8Array, Int16Array, Int32Array, Int32Builder, Int64Array, ListBuilder, MapBuilder,
+        StringArray, StringBuilder, StructArray, UInt32Builder,
     };
-    use arrow::datatypes::{DataType, Field, Fields, Schema};
+    use arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema};
+    use bigdecimal::BigDecimal;
+    use bigdecimal::num_bigint::BigInt;
 
-    fn infer_fluss_type(arrow_dt: &arrow_schema::DataType) -> crate::metadata::DataType {
+    fn infer_fluss_type(arrow_dt: &ArrowDataType) -> DataType {
         match arrow_dt {
-            arrow_schema::DataType::Int32 => {
-                crate::metadata::DataType::Int(crate::metadata::IntType::new())
+            ArrowDataType::Int32 => DataType::Int(IntType::new()),
+            ArrowDataType::List(f) => {
+                DataType::Array(ArrayType::new(infer_fluss_type(f.data_type())))
             }
-            arrow_schema::DataType::List(f) => crate::metadata::DataType::Array(
-                crate::metadata::ArrayType::new(infer_fluss_type(f.data_type())),
-            ),
-            _ => crate::metadata::DataType::Int(crate::metadata::IntType::new()),
+            _ => DataType::Int(IntType::new()),
         }
     }
 
@@ -1214,7 +263,7 @@ mod tests {
         let batch =
             RecordBatch::try_from_iter(vec![("arr", array)]).expect("record batch with one column");
         let row_type = Arc::new(RowType::with_data_types(vec![dt]));
-        ColumnarRow::new(Arc::new(batch), row_type, 0, None)
+        ColumnarRow::new(Arc::new(batch), row_type, 0, None).expect("ColumnarRow")
     }
 
     #[test]
@@ -1249,7 +298,8 @@ mod tests {
         )
         .expect("record batch");
 
-        let mut row = ColumnarRow::new(Arc::new(batch), Arc::new(RowType::new(vec![])), 0, None);
+        let mut row = ColumnarRow::new(Arc::new(batch), Arc::new(RowType::new(vec![])), 0, None)
+            .expect("ColumnarRow");
         assert_eq!(row.get_field_count(), 10);
         assert!(row.get_boolean(0).unwrap());
         assert_eq!(row.get_byte(1).unwrap(), 1);
@@ -1267,19 +317,15 @@ mod tests {
 
     #[test]
     fn columnar_row_reads_decimal() {
-        use bigdecimal::{BigDecimal, num_bigint::BigInt};
-
-        // Test with Decimal128
         let schema = Arc::new(Schema::new(vec![
             Field::new("dec1", ArrowDataType::Decimal128(10, 2), false),
             Field::new("dec2", ArrowDataType::Decimal128(20, 5), false),
             Field::new("dec3", ArrowDataType::Decimal128(38, 10), false),
         ]));
 
-        // Create decimal values: 123.45, 12345.67890, large decimal
-        let dec1_val = 12345i128; // 123.45 with scale 2
-        let dec2_val = 1234567890i128; // 12345.67890 with scale 5
-        let dec3_val = 999999999999999999i128; // Large value (18 nines) with scale 10
+        let dec1_val = 12345i128;
+        let dec2_val = 1234567890i128;
+        let dec3_val = 999999999999999999i128;
 
         let batch = RecordBatch::try_new(
             schema,
@@ -1303,10 +349,10 @@ mod tests {
         )
         .expect("record batch");
 
-        let row = ColumnarRow::new(Arc::new(batch), Arc::new(RowType::new(vec![])), 0, None);
+        let row = ColumnarRow::new(Arc::new(batch), Arc::new(RowType::new(vec![])), 0, None)
+            .expect("ColumnarRow");
         assert_eq!(row.get_field_count(), 3);
 
-        // Verify decimal values
         assert_eq!(
             row.get_decimal(0, 10, 2).unwrap(),
             Decimal::from_big_decimal(BigDecimal::new(BigInt::from(12345), 2), 10, 2).unwrap()
@@ -1356,7 +402,7 @@ mod tests {
         let arr = row.get_array(0).unwrap();
         assert_eq!(arr.size(), 3);
         assert_eq!(arr.get_int(0).unwrap(), 1);
-        assert!(arr.is_null_at(1));
+        assert!(arr.is_null_at(1).unwrap());
         assert_eq!(arr.get_int(2).unwrap(), 3);
     }
 
@@ -1364,16 +410,13 @@ mod tests {
     fn columnar_row_get_array_nested_array() {
         let mut outer = ListBuilder::new(ListBuilder::new(Int32Builder::new()));
 
-        // first nested array: [1, 2]
         outer.values().values().append_value(1);
         outer.values().values().append_value(2);
         outer.values().append(true);
 
-        // second nested array: [99]
         outer.values().values().append_value(99);
         outer.values().append(true);
 
-        // one row containing two nested arrays
         outer.append(true);
         let array = Arc::new(outer.finish()) as ArrayRef;
 
@@ -1397,7 +440,7 @@ mod tests {
         let row = single_column_row(array);
         let err = row.get_array(0).unwrap_err();
         assert!(
-            err.to_string().contains("expected Array type"),
+            err.to_string().contains("expected ARRAY column"),
             "unexpected error: {err}"
         );
     }
@@ -1410,18 +453,14 @@ mod tests {
         let array = Arc::new(builder.finish()) as ArrayRef;
 
         let batch = RecordBatch::try_from_iter(vec![("arr", array)]).expect("record batch");
-        // We manually create a row type that claims to be Array(Int) even though it's List(UInt32)
-        // to test the validation in get_array.
         let row_type = Arc::new(RowType::new(vec![DataField::new(
             "arr",
-            crate::metadata::DataTypes::array(crate::metadata::DataTypes::int()),
+            DataTypes::array(DataTypes::int()),
             None,
         )]));
-        let row = ColumnarRow::new(Arc::new(batch), row_type, 0, None);
-
-        let err = row.get_array(0).unwrap_err();
+        let err = ColumnarRow::new(Arc::new(batch), row_type, 0, None).unwrap_err();
         assert!(
-            err.to_string().contains("expected Int32Type"),
+            err.to_string().contains("expected Int32Array"),
             "unexpected error: {err}"
         );
     }
@@ -1435,7 +474,7 @@ mod tests {
         let struct_array = StructArray::new(child_fields.clone(), child_arrays, None);
         let schema = Arc::new(Schema::new(vec![Field::new(
             field_name,
-            DataType::Struct(child_fields),
+            ArrowDataType::Struct(child_fields),
             false,
         )]));
         Arc::new(RecordBatch::try_new(schema, vec![Arc::new(struct_array)]).expect("record batch"))
@@ -1444,8 +483,8 @@ mod tests {
     #[test]
     fn columnar_row_reads_nested_row() {
         let child_fields = Fields::from(vec![
-            Field::new("x", DataType::Int32, false),
-            Field::new("s", DataType::Utf8, false),
+            Field::new("x", ArrowDataType::Int32, false),
+            Field::new("s", ArrowDataType::Utf8, false),
         ]);
         let child_arrays: Vec<Arc<dyn Array>> = vec![
             Arc::new(Int32Array::from(vec![42, 99])),
@@ -1453,15 +492,14 @@ mod tests {
         ];
         let batch = make_struct_batch("nested", child_fields, child_arrays, 2);
 
-        let mut row = ColumnarRow::new(batch, Arc::new(RowType::new(vec![])), 0, None);
+        let mut row =
+            ColumnarRow::new(batch, Arc::new(RowType::new(vec![])), 0, None).expect("ColumnarRow");
 
-        // row_id = 0
         let nested = row.get_row(0).unwrap();
         assert_eq!(nested.get_field_count(), 2);
         assert_eq!(nested.get_int(0).unwrap(), 42);
         assert_eq!(nested.get_string(1).unwrap(), "hello");
 
-        // row_id = 1
         row.set_row_id(1);
         let nested = row.get_row(0).unwrap();
         assert_eq!(nested.get_int(0).unwrap(), 99);
@@ -1470,8 +508,7 @@ mod tests {
 
     #[test]
     fn columnar_row_reads_deeply_nested_row() {
-        // Build: outer struct { i32, inner struct { string } }
-        let inner_fields = Fields::from(vec![Field::new("s", DataType::Utf8, false)]);
+        let inner_fields = Fields::from(vec![Field::new("s", ArrowDataType::Utf8, false)]);
         let inner_array = Arc::new(StructArray::new(
             inner_fields.clone(),
             vec![Arc::new(StringArray::from(vec!["deep", "deeper"])) as Arc<dyn Array>],
@@ -1479,8 +516,8 @@ mod tests {
         ));
 
         let outer_fields = Fields::from(vec![
-            Field::new("n", DataType::Int32, false),
-            Field::new("inner", DataType::Struct(inner_fields), false),
+            Field::new("n", ArrowDataType::Int32, false),
+            Field::new("inner", ArrowDataType::Struct(inner_fields), false),
         ]);
         let outer_array = Arc::new(StructArray::new(
             outer_fields.clone(),
@@ -1493,21 +530,20 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "outer",
-            DataType::Struct(outer_fields),
+            ArrowDataType::Struct(outer_fields),
             false,
         )]));
         let batch =
             Arc::new(RecordBatch::try_new(schema, vec![outer_array]).expect("record batch"));
 
-        let mut row = ColumnarRow::new(batch, Arc::new(RowType::new(vec![])), 0, None);
+        let mut row =
+            ColumnarRow::new(batch, Arc::new(RowType::new(vec![])), 0, None).expect("ColumnarRow");
 
-        // row_id = 0
         let outer = row.get_row(0).unwrap();
         assert_eq!(outer.get_int(0).unwrap(), 1);
         let inner = outer.get_row(1).unwrap();
         assert_eq!(inner.get_string(0).unwrap(), "deep");
 
-        // row_id = 1
         row.set_row_id(1);
         let outer = row.get_row(0).unwrap();
         assert_eq!(outer.get_int(0).unwrap(), 2);
@@ -1516,18 +552,17 @@ mod tests {
     }
 
     #[test]
-    fn columnar_row_get_row_cache_invalidated_on_set_row_id() {
-        let child_fields = Fields::from(vec![Field::new("x", DataType::Int32, false)]);
+    fn columnar_row_nested_row_follows_outer_row_id() {
+        let child_fields = Fields::from(vec![Field::new("x", ArrowDataType::Int32, false)]);
         let child_arrays: Vec<Arc<dyn Array>> = vec![Arc::new(Int32Array::from(vec![10, 20]))];
         let batch = make_struct_batch("s", child_fields, child_arrays, 2);
 
-        let mut row = ColumnarRow::new(batch, Arc::new(RowType::new(vec![])), 0, None);
+        let mut row =
+            ColumnarRow::new(batch, Arc::new(RowType::new(vec![])), 0, None).expect("ColumnarRow");
 
-        // row_id = 0: nested x = 10
         let nested_0 = row.get_row(0).unwrap();
         assert_eq!(nested_0.get_int(0).unwrap(), 10);
 
-        // After set_row_id(1), cache is cleared → nested x = 20
         row.set_row_id(1);
         let nested_1 = row.get_row(0).unwrap();
         assert_eq!(nested_1.get_int(0).unwrap(), 20);
@@ -1535,10 +570,6 @@ mod tests {
 
     #[test]
     fn columnar_row_get_map_accepts_non_nullable_key_from_map_type() {
-        use crate::metadata::DataTypes;
-        use arrow::array::{MapBuilder, StringBuilder};
-
-        // Arrow map column with INT keys, STRING values.
         let mut builder = MapBuilder::new(None, Int32Builder::new(), StringBuilder::new());
         builder.keys().append_value(1);
         builder.values().append_value("a");
@@ -1552,7 +583,7 @@ mod tests {
 
         let map_type = DataTypes::map(DataTypes::int(), DataTypes::string());
         let row_type = Arc::new(RowType::with_data_types(vec![map_type]));
-        let row = ColumnarRow::new(batch, row_type, 0, None);
+        let row = ColumnarRow::new(batch, row_type, 0, None).expect("ColumnarRow");
 
         let fluss_map = row
             .get_map(0)
@@ -1564,10 +595,6 @@ mod tests {
 
     #[test]
     fn columnar_row_reads_row_containing_map() {
-        use crate::metadata::DataTypes;
-        use arrow::array::{MapBuilder, StringBuilder};
-
-        // Inner Map<String, Int> Arrow column with one entry per row, 2 rows.
         let mut mb = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new());
         mb.keys().append_value("k1");
         mb.values().append_value(42);
@@ -1577,10 +604,9 @@ mod tests {
         mb.append(true).unwrap();
         let map_arr = mb.finish();
 
-        // Struct { id: Int32, m: Map<String, Int> }
         let id_arr = Int32Array::from(vec![10, 20]);
         let struct_fields = Fields::from(vec![
-            Field::new("id", DataType::Int32, false),
+            Field::new("id", ArrowDataType::Int32, false),
             Field::new("m", map_arr.data_type().clone(), false),
         ]);
         let struct_arr = Arc::new(StructArray::new(
@@ -1590,26 +616,26 @@ mod tests {
         ));
         let schema = Arc::new(Schema::new(vec![Field::new(
             "outer",
-            DataType::Struct(struct_fields),
+            ArrowDataType::Struct(struct_fields),
             false,
         )]));
         let batch = Arc::new(RecordBatch::try_new(schema, vec![struct_arr]).expect("record batch"));
 
-        // Fluss outer ROW<id INT, m MAP<STRING, INT>>
         let inner_row_type = RowType::with_data_types(vec![
             DataTypes::int(),
             DataTypes::map(DataTypes::string(), DataTypes::int()),
         ]);
-        let outer_row_type = Arc::new(RowType::with_data_types(vec![
-            crate::metadata::DataType::Row(inner_row_type),
-        ]));
+        let outer_row_type = Arc::new(RowType::with_data_types(vec![DataType::Row(
+            inner_row_type,
+        )]));
 
         let mut row = ColumnarRow::new(
             batch,
             outer_row_type.clone(),
             0,
             Some(outer_row_type.clone()),
-        );
+        )
+        .expect("ColumnarRow");
 
         let nested = row
             .get_row(0)
@@ -1620,7 +646,6 @@ mod tests {
         assert_eq!(inner_map.key_array().get_string(0).unwrap(), "k1");
         assert_eq!(inner_map.value_array().get_int(0).unwrap(), 42);
 
-        // Verify cache invalidation across rows works for Row-with-Map too.
         row.set_row_id(1);
         let nested = row.get_row(0).expect("row 1 must read");
         assert_eq!(nested.get_int(0).unwrap(), 20);
@@ -1631,9 +656,6 @@ mod tests {
 
     #[test]
     fn columnar_row_reads_array_of_maps() {
-        use crate::metadata::DataTypes;
-        use arrow::array::{ListBuilder, MapBuilder, StringBuilder};
-
         // One row whose ARRAY<MAP<STRING, INT>> contains two maps:
         // [{"k1" -> 1}, {"k2" -> 2, "k3" -> 3}].
         let mut outer = ListBuilder::new(MapBuilder::new(
@@ -1643,11 +665,9 @@ mod tests {
         ));
         {
             let mb = outer.values();
-            // Map 0: {"k1" -> 1}
             mb.keys().append_value("k1");
             mb.values().append_value(1);
             mb.append(true).unwrap();
-            // Map 1: {"k2" -> 2, "k3" -> 3}
             mb.keys().append_value("k2");
             mb.values().append_value(2);
             mb.keys().append_value("k3");
@@ -1664,21 +684,17 @@ mod tests {
 
         let array_type = DataTypes::array(DataTypes::map(DataTypes::string(), DataTypes::int()));
         let row_type = Arc::new(RowType::with_data_types(vec![array_type]));
-        let row = ColumnarRow::new(batch, row_type, 0, None);
+        let row = ColumnarRow::new(batch, row_type, 0, None).expect("ColumnarRow");
 
         let arr = row.get_array(0).expect("get_array on ARRAY<MAP> must work");
         assert_eq!(arr.size(), 2);
 
-        let m0 = arr
-            .get_map(0, &DataTypes::string(), &DataTypes::int())
-            .unwrap();
+        let m0 = arr.get_map(0).expect("nested map 0");
         assert_eq!(m0.size(), 1);
         assert_eq!(m0.key_array().get_string(0).unwrap(), "k1");
         assert_eq!(m0.value_array().get_int(0).unwrap(), 1);
 
-        let m1 = arr
-            .get_map(1, &DataTypes::string(), &DataTypes::int())
-            .unwrap();
+        let m1 = arr.get_map(1).expect("nested map 1");
         assert_eq!(m1.size(), 2);
         assert_eq!(m1.key_array().get_string(0).unwrap(), "k2");
         assert_eq!(m1.value_array().get_int(0).unwrap(), 2);
@@ -1688,9 +704,6 @@ mod tests {
 
     #[test]
     fn columnar_row_get_map_rejects_real_type_mismatch() {
-        use crate::metadata::DataTypes;
-        use arrow::array::{MapBuilder, StringBuilder};
-
         let mut mb = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new());
         mb.keys().append_value("k");
         mb.values().append_value(1);
@@ -1702,14 +715,11 @@ mod tests {
         let batch =
             Arc::new(RecordBatch::try_new(schema, vec![Arc::new(map_arr)]).expect("record batch"));
 
-        // Caller mis-declares the value type as STRING.
         let row_type = Arc::new(RowType::with_data_types(vec![DataTypes::map(
             DataTypes::string(),
             DataTypes::string(),
         )]));
-        let row = ColumnarRow::new(batch, row_type, 0, None);
-
-        let err = row.get_map(0).expect_err("type mismatch must error");
+        let err = ColumnarRow::new(batch, row_type, 0, None).expect_err("type mismatch must error");
         let msg = err.to_string();
         assert!(
             msg.contains("expected StringArray"),

--- a/crates/fluss/src/row/column.rs
+++ b/crates/fluss/src/row/column.rs
@@ -67,16 +67,23 @@ impl ColumnarRow {
         self.row_id
     }
 
-    /// Returns the source `RecordBatch`. Panics on a nested cursor (returned
-    /// from [`DataGetters::get_row`]) — those have no batch of their own.
-    pub fn get_record_batch(&self) -> &RecordBatch {
-        self.batch.record_batch.as_ref().expect(
-            "get_record_batch called on a nested ColumnarRow; only the outer scan-level \
-             cursor carries a RecordBatch",
-        )
+    /// Returns the source `RecordBatch`, or `None` for a nested cursor
+    /// (from [`DataGetters::get_row`]), which has no batch of its own.
+    pub fn get_record_batch(&self) -> Option<&RecordBatch> {
+        self.batch.record_batch.as_ref()
     }
 
+    /// Resolves the column at `pos`, bounds-checking `row_id` first — the
+    /// single guard shared by every accessor.
     fn column(&self, pos: usize) -> Result<&TypedColumn> {
+        if self.row_id >= self.batch.num_rows {
+            return Err(IllegalArgument {
+                message: format!(
+                    "row index {} out of bounds (batch has {} rows)",
+                    self.row_id, self.batch.num_rows
+                ),
+            });
+        }
         self.batch.columns.get(pos).ok_or_else(|| IllegalArgument {
             message: format!(
                 "column index {pos} out of bounds (batch has {} columns)",

--- a/crates/fluss/src/row/column_vector.rs
+++ b/crates/fluss/src/row/column_vector.rs
@@ -1,0 +1,650 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Typed Arrow column vectors built once per `RecordBatch`. Row accessors
+//! match on the variant — no per-call downcasting. Nested `ARRAY<T>` /
+//! `MAP<K,V>` / `ROW` columns own their element vectors recursively.
+
+use crate::error::Error::IllegalArgument;
+use crate::error::{Error, Result};
+use crate::metadata::{DataType, RowType};
+use crate::row::Decimal;
+use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz};
+use arrow::array::{
+    Array, BinaryArray, BooleanArray, Date32Array, Decimal128Array, FixedSizeBinaryArray,
+    Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, ListArray, MapArray,
+    RecordBatch, StringArray, StructArray, Time32MillisecondArray, Time32SecondArray,
+    Time64MicrosecondArray, Time64NanosecondArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
+};
+use arrow::datatypes::{DataType as ArrowDataType, TimeUnit};
+use std::sync::Arc;
+
+/// One typed Arrow column.
+#[derive(Debug, Clone)]
+pub(crate) enum TypedColumn {
+    Boolean(BooleanArray),
+    TinyInt(Int8Array),
+    SmallInt(Int16Array),
+    Int(Int32Array),
+    BigInt(Int64Array),
+    Float(Float32Array),
+    Double(Float64Array),
+    /// Covers both `STRING` and `CHAR(n)` — both serialize as Arrow `Utf8`.
+    String(StringArray),
+    Binary(FixedSizeBinaryArray),
+    Bytes(BinaryArray),
+    /// Companion `i64` is the Arrow scale, extracted once at build.
+    Decimal(Decimal128Array, i64),
+    Date(Date32Array),
+    Time(TimeColumn),
+    /// `TIMESTAMP` and `TIMESTAMP_LTZ` share the Arrow representation; the
+    /// distinction is purely semantic.
+    Timestamp(TimestampColumn),
+    TimestampLtz(TimestampColumn),
+    Array(ListArray, Box<TypedColumn>),
+    Map(MapArray, Box<TypedColumn>, Box<TypedColumn>),
+    Row(StructArray, Arc<TypedBatch>),
+}
+
+/// Arrow time-of-day in whichever unit the writer chose. Read accessors
+/// down-convert to milliseconds since midnight per Fluss's `get_time` contract.
+#[derive(Debug, Clone)]
+pub(crate) enum TimeColumn {
+    Second(Time32SecondArray),
+    Millisecond(Time32MillisecondArray),
+    Microsecond(Time64MicrosecondArray),
+    Nanosecond(Time64NanosecondArray),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TimestampColumn {
+    Second(TimestampSecondArray),
+    Millisecond(TimestampMillisecondArray),
+    Microsecond(TimestampMicrosecondArray),
+    Nanosecond(TimestampNanosecondArray),
+}
+
+/// Typed Arrow columns sharing a row count. Built once per `ArrowReader` and
+/// shared via `Arc` across rows. `record_batch` is `Some` only for the outer
+/// batch (the FFI/pyarrow path hands it back); nested batches built from a
+/// `StructArray` carry `None`.
+#[derive(Debug)]
+pub(crate) struct TypedBatch {
+    pub(crate) columns: Vec<TypedColumn>,
+    pub(crate) num_rows: usize,
+    pub(crate) record_batch: Option<RecordBatch>,
+}
+
+impl TypedBatch {
+    /// Builds a typed batch from `batch` + `row_type`, recursing into nested
+    /// `ARRAY` / `MAP` / `ROW` columns.
+    pub(crate) fn build(batch: &RecordBatch, row_type: &RowType) -> Result<Self> {
+        let fields = row_type.fields();
+        if batch.num_columns() != fields.len() {
+            return Err(IllegalArgument {
+                message: format!(
+                    "RecordBatch has {} columns but RowType has {} fields",
+                    batch.num_columns(),
+                    fields.len()
+                ),
+            });
+        }
+        let mut columns = Vec::with_capacity(fields.len());
+        for (i, field) in fields.iter().enumerate() {
+            columns.push(TypedColumn::build(
+                batch.column(i).as_ref(),
+                &field.data_type,
+            )?);
+        }
+        Ok(TypedBatch {
+            columns,
+            num_rows: batch.num_rows(),
+            record_batch: Some(batch.clone()),
+        })
+    }
+
+    fn from_struct(struct_arr: &StructArray, row_type: &RowType) -> Result<Self> {
+        let fields = row_type.fields();
+        if struct_arr.num_columns() != fields.len() {
+            return Err(IllegalArgument {
+                message: format!(
+                    "Arrow StructArray has {} columns but RowType has {} fields",
+                    struct_arr.num_columns(),
+                    fields.len()
+                ),
+            });
+        }
+        let mut columns = Vec::with_capacity(fields.len());
+        for (i, field) in fields.iter().enumerate() {
+            columns.push(TypedColumn::build(
+                struct_arr.column(i).as_ref(),
+                &field.data_type,
+            )?);
+        }
+        Ok(TypedBatch {
+            columns,
+            num_rows: struct_arr.len(),
+            record_batch: None,
+        })
+    }
+}
+
+impl TypedColumn {
+    /// Recursively types `array` against the Fluss `fluss_type` it represents.
+    pub(crate) fn build(array: &dyn Array, fluss_type: &DataType) -> Result<Self> {
+        match fluss_type {
+            DataType::Boolean(_) => Ok(Self::Boolean(downcast(array, "BooleanArray")?)),
+            DataType::TinyInt(_) => Ok(Self::TinyInt(downcast(array, "Int8Array")?)),
+            DataType::SmallInt(_) => Ok(Self::SmallInt(downcast(array, "Int16Array")?)),
+            DataType::Int(_) => Ok(Self::Int(downcast(array, "Int32Array")?)),
+            DataType::BigInt(_) => Ok(Self::BigInt(downcast(array, "Int64Array")?)),
+            DataType::Float(_) => Ok(Self::Float(downcast(array, "Float32Array")?)),
+            DataType::Double(_) => Ok(Self::Double(downcast(array, "Float64Array")?)),
+            DataType::Char(_) | DataType::String(_) => {
+                Ok(Self::String(downcast(array, "StringArray")?))
+            }
+            DataType::Binary(_) => Ok(Self::Binary(downcast(array, "FixedSizeBinaryArray")?)),
+            DataType::Bytes(_) => Ok(Self::Bytes(downcast(array, "BinaryArray")?)),
+            DataType::Decimal(_) => {
+                let arr: Decimal128Array = downcast(array, "Decimal128Array")?;
+                let arrow_scale = match arr.data_type() {
+                    ArrowDataType::Decimal128(_, s) => *s as i64,
+                    other => {
+                        return Err(IllegalArgument {
+                            message: format!(
+                                "Decimal128Array carries unexpected data type: {other:?}"
+                            ),
+                        });
+                    }
+                };
+                Ok(Self::Decimal(arr, arrow_scale))
+            }
+            DataType::Date(_) => Ok(Self::Date(downcast(array, "Date32Array")?)),
+            DataType::Time(_) => Ok(Self::Time(TimeColumn::build(array)?)),
+            DataType::Timestamp(_) => Ok(Self::Timestamp(TimestampColumn::build(array)?)),
+            DataType::TimestampLTz(_) => Ok(Self::TimestampLtz(TimestampColumn::build(array)?)),
+            DataType::Array(at) => {
+                let list_arr: ListArray = downcast(array, "ListArray")?;
+                let element = Self::build(list_arr.values().as_ref(), at.get_element_type())?;
+                Ok(Self::Array(list_arr, Box::new(element)))
+            }
+            DataType::Map(mt) => {
+                let map_arr: MapArray = downcast(array, "MapArray")?;
+                let key_typed = Self::build(map_arr.keys().as_ref(), mt.key_type())?;
+                let value_typed = Self::build(map_arr.values().as_ref(), mt.value_type())?;
+                Ok(Self::Map(
+                    map_arr,
+                    Box::new(key_typed),
+                    Box::new(value_typed),
+                ))
+            }
+            DataType::Row(rt) => {
+                let struct_arr: StructArray = downcast(array, "StructArray")?;
+                let inner = TypedBatch::from_struct(&struct_arr, rt)?;
+                Ok(Self::Row(struct_arr, Arc::new(inner)))
+            }
+        }
+    }
+
+    /// Returns the underlying Arrow array for length / nullability access.
+    fn outer_array(&self) -> &dyn Array {
+        match self {
+            Self::Boolean(a) => a,
+            Self::TinyInt(a) => a,
+            Self::SmallInt(a) => a,
+            Self::Int(a) => a,
+            Self::BigInt(a) => a,
+            Self::Float(a) => a,
+            Self::Double(a) => a,
+            Self::String(a) => a,
+            Self::Binary(a) => a,
+            Self::Bytes(a) => a,
+            Self::Decimal(a, _) => a,
+            Self::Date(a) => a,
+            Self::Time(t) => t.as_array(),
+            Self::Timestamp(t) | Self::TimestampLtz(t) => t.as_array(),
+            Self::Array(a, _) => a,
+            Self::Map(a, _, _) => a,
+            Self::Row(a, _) => a,
+        }
+    }
+
+    pub(crate) fn is_null_at(&self, row_id: usize) -> bool {
+        self.outer_array().is_null(row_id)
+    }
+
+    pub(crate) fn get_boolean(&self, row_id: usize) -> Result<bool> {
+        match self {
+            Self::Boolean(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("BOOLEAN")),
+        }
+    }
+
+    pub(crate) fn get_byte(&self, row_id: usize) -> Result<i8> {
+        match self {
+            Self::TinyInt(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("TINYINT")),
+        }
+    }
+
+    pub(crate) fn get_short(&self, row_id: usize) -> Result<i16> {
+        match self {
+            Self::SmallInt(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("SMALLINT")),
+        }
+    }
+
+    pub(crate) fn get_int(&self, row_id: usize) -> Result<i32> {
+        match self {
+            Self::Int(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("INT")),
+        }
+    }
+
+    pub(crate) fn get_long(&self, row_id: usize) -> Result<i64> {
+        match self {
+            Self::BigInt(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("BIGINT")),
+        }
+    }
+
+    pub(crate) fn get_float(&self, row_id: usize) -> Result<f32> {
+        match self {
+            Self::Float(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("FLOAT")),
+        }
+    }
+
+    pub(crate) fn get_double(&self, row_id: usize) -> Result<f64> {
+        match self {
+            Self::Double(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("DOUBLE")),
+        }
+    }
+
+    pub(crate) fn get_string(&self, row_id: usize) -> Result<&str> {
+        match self {
+            Self::String(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("STRING")),
+        }
+    }
+
+    pub(crate) fn get_char(&self, row_id: usize) -> Result<&str> {
+        self.get_string(row_id)
+    }
+
+    pub(crate) fn get_binary(&self, row_id: usize) -> Result<&[u8]> {
+        match self {
+            Self::Binary(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("BINARY")),
+        }
+    }
+
+    pub(crate) fn get_bytes(&self, row_id: usize) -> Result<&[u8]> {
+        match self {
+            Self::Bytes(a) => Ok(a.value(row_id)),
+            _ => Err(self.type_mismatch("BYTES")),
+        }
+    }
+
+    pub(crate) fn get_decimal(&self, row_id: usize, precision: u32, scale: u32) -> Result<Decimal> {
+        match self {
+            Self::Decimal(a, arrow_scale) => {
+                Decimal::from_arrow_decimal128(a.value(row_id), *arrow_scale, precision, scale)
+            }
+            _ => Err(self.type_mismatch("DECIMAL")),
+        }
+    }
+
+    pub(crate) fn get_date(&self, row_id: usize) -> Result<Date> {
+        match self {
+            Self::Date(a) => Ok(Date::new(a.value(row_id))),
+            _ => Err(self.type_mismatch("DATE")),
+        }
+    }
+
+    pub(crate) fn get_time(&self, row_id: usize) -> Result<Time> {
+        match self {
+            Self::Time(t) => Ok(Time::new(t.get_millis(row_id))),
+            _ => Err(self.type_mismatch("TIME")),
+        }
+    }
+
+    pub(crate) fn get_timestamp_ntz(&self, row_id: usize) -> Result<TimestampNtz> {
+        match self {
+            Self::Timestamp(t) => {
+                let (millis, nanos) = t.get_millis_nanos(row_id);
+                if nanos == 0 {
+                    Ok(TimestampNtz::new(millis))
+                } else {
+                    TimestampNtz::from_millis_nanos(millis, nanos)
+                }
+            }
+            _ => Err(self.type_mismatch("TIMESTAMP")),
+        }
+    }
+
+    pub(crate) fn get_timestamp_ltz(&self, row_id: usize) -> Result<TimestampLtz> {
+        match self {
+            Self::TimestampLtz(t) => {
+                let (millis, nanos) = t.get_millis_nanos(row_id);
+                if nanos == 0 {
+                    Ok(TimestampLtz::new(millis))
+                } else {
+                    TimestampLtz::from_millis_nanos(millis, nanos)
+                }
+            }
+            _ => Err(self.type_mismatch("TIMESTAMP_LTZ")),
+        }
+    }
+
+    fn type_mismatch(&self, expected: &str) -> Error {
+        IllegalArgument {
+            message: format!(
+                "expected {expected} column, got Arrow type {:?}",
+                self.outer_array().data_type()
+            ),
+        }
+    }
+}
+
+impl TimeColumn {
+    fn build(array: &dyn Array) -> Result<Self> {
+        match array.data_type() {
+            ArrowDataType::Time32(TimeUnit::Second) => {
+                Ok(Self::Second(downcast(array, "Time32SecondArray")?))
+            }
+            ArrowDataType::Time32(TimeUnit::Millisecond) => Ok(Self::Millisecond(downcast(
+                array,
+                "Time32MillisecondArray",
+            )?)),
+            ArrowDataType::Time64(TimeUnit::Microsecond) => Ok(Self::Microsecond(downcast(
+                array,
+                "Time64MicrosecondArray",
+            )?)),
+            ArrowDataType::Time64(TimeUnit::Nanosecond) => {
+                Ok(Self::Nanosecond(downcast(array, "Time64NanosecondArray")?))
+            }
+            other => Err(IllegalArgument {
+                message: format!("expected Time column, got {other:?}"),
+            }),
+        }
+    }
+
+    fn as_array(&self) -> &dyn Array {
+        match self {
+            Self::Second(a) => a,
+            Self::Millisecond(a) => a,
+            Self::Microsecond(a) => a,
+            Self::Nanosecond(a) => a,
+        }
+    }
+
+    fn get_millis(&self, row_id: usize) -> i32 {
+        match self {
+            Self::Second(a) => a.value(row_id) * 1000,
+            Self::Millisecond(a) => a.value(row_id),
+            Self::Microsecond(a) => (a.value(row_id) / 1_000) as i32,
+            Self::Nanosecond(a) => (a.value(row_id) / 1_000_000) as i32,
+        }
+    }
+}
+
+impl TimestampColumn {
+    fn build(array: &dyn Array) -> Result<Self> {
+        match array.data_type() {
+            ArrowDataType::Timestamp(TimeUnit::Second, _) => {
+                Ok(Self::Second(downcast(array, "TimestampSecondArray")?))
+            }
+            ArrowDataType::Timestamp(TimeUnit::Millisecond, _) => Ok(Self::Millisecond(downcast(
+                array,
+                "TimestampMillisecondArray",
+            )?)),
+            ArrowDataType::Timestamp(TimeUnit::Microsecond, _) => Ok(Self::Microsecond(downcast(
+                array,
+                "TimestampMicrosecondArray",
+            )?)),
+            ArrowDataType::Timestamp(TimeUnit::Nanosecond, _) => Ok(Self::Nanosecond(downcast(
+                array,
+                "TimestampNanosecondArray",
+            )?)),
+            other => Err(IllegalArgument {
+                message: format!("expected Timestamp column, got {other:?}"),
+            }),
+        }
+    }
+
+    fn as_array(&self) -> &dyn Array {
+        match self {
+            Self::Second(a) => a,
+            Self::Millisecond(a) => a,
+            Self::Microsecond(a) => a,
+            Self::Nanosecond(a) => a,
+        }
+    }
+
+    /// Reads as (millis-since-epoch, nanos-within-millis). Euclidean division
+    /// keeps `nanos` in `[0, 999_999]` even for pre-epoch values.
+    fn get_millis_nanos(&self, row_id: usize) -> (i64, i32) {
+        match self {
+            Self::Second(a) => (a.value(row_id) * 1_000, 0),
+            Self::Millisecond(a) => (a.value(row_id), 0),
+            Self::Microsecond(a) => {
+                let v = a.value(row_id);
+                (v.div_euclid(1_000), (v.rem_euclid(1_000) * 1_000) as i32)
+            }
+            Self::Nanosecond(a) => {
+                let v = a.value(row_id);
+                (v.div_euclid(1_000_000), v.rem_euclid(1_000_000) as i32)
+            }
+        }
+    }
+}
+
+fn downcast<T: Array + Clone + 'static>(array: &dyn Array, expected: &str) -> Result<T> {
+    array
+        .as_any()
+        .downcast_ref::<T>()
+        .cloned()
+        .ok_or_else(|| IllegalArgument {
+            message: format!(
+                "expected {expected}, got Arrow type {:?}",
+                array.data_type()
+            ),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::{DataField, DataTypes};
+    use arrow::array::{ArrayRef, Decimal128Array};
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{Field, Fields, Schema};
+
+    fn batch(columns: Vec<(&str, ArrayRef)>) -> RecordBatch {
+        let fields: Vec<Field> = columns
+            .iter()
+            .map(|(n, a)| Field::new(*n, a.data_type().clone(), true))
+            .collect();
+        let arrays: Vec<ArrayRef> = columns.into_iter().map(|(_, a)| a).collect();
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays).expect("batch")
+    }
+
+    #[test]
+    fn builds_and_reads_primitives() {
+        let b = batch(vec![
+            ("i", Arc::new(Int32Array::from(vec![1, 2, 3])) as ArrayRef),
+            (
+                "s",
+                Arc::new(StringArray::from(vec!["hello", "world", "!"])) as ArrayRef,
+            ),
+            (
+                "b",
+                Arc::new(BooleanArray::from(vec![true, false, true])) as ArrayRef,
+            ),
+        ]);
+        let rt = RowType::new(vec![
+            DataField::new("i", DataTypes::int(), None),
+            DataField::new("s", DataTypes::string(), None),
+            DataField::new("b", DataTypes::boolean(), None),
+        ]);
+
+        let tb = TypedBatch::build(&b, &rt).expect("build");
+
+        assert_eq!(tb.num_rows, 3);
+        assert_eq!(tb.columns.len(), 3);
+
+        assert_eq!(tb.columns[0].get_int(0).unwrap(), 1);
+        assert_eq!(tb.columns[0].get_int(2).unwrap(), 3);
+        assert_eq!(tb.columns[1].get_string(0).unwrap(), "hello");
+        assert!(tb.columns[2].get_boolean(0).unwrap());
+        assert!(!tb.columns[2].get_boolean(1).unwrap());
+    }
+
+    #[test]
+    fn type_mismatch_is_clear_error() {
+        let b = batch(vec![("i", Arc::new(Int32Array::from(vec![1])) as ArrayRef)]);
+        let rt = RowType::new(vec![DataField::new("i", DataTypes::int(), None)]);
+        let tb = TypedBatch::build(&b, &rt).expect("build");
+
+        let err = tb.columns[0].get_string(0).unwrap_err().to_string();
+        assert!(err.contains("expected STRING"), "{err}");
+    }
+
+    #[test]
+    fn build_fails_on_arity_mismatch() {
+        let b = batch(vec![("i", Arc::new(Int32Array::from(vec![1])) as ArrayRef)]);
+        let rt = RowType::new(vec![
+            DataField::new("i", DataTypes::int(), None),
+            DataField::new("j", DataTypes::int(), None),
+        ]);
+
+        let err = TypedBatch::build(&b, &rt).unwrap_err().to_string();
+        assert!(
+            err.contains("1 columns") && err.contains("2 fields"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn null_check_uses_arrow_validity_buffer() {
+        let arr = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let b = batch(vec![("i", Arc::new(arr) as ArrayRef)]);
+        let rt = RowType::new(vec![DataField::new("i", DataTypes::int(), None)]);
+        let tb = TypedBatch::build(&b, &rt).expect("build");
+
+        assert!(!tb.columns[0].is_null_at(0));
+        assert!(tb.columns[0].is_null_at(1));
+        assert!(!tb.columns[0].is_null_at(2));
+    }
+
+    #[test]
+    fn recursive_array_builds_element_vector() {
+        let inner = Int32Array::from(vec![10, 20, 30, 40]);
+        let offsets = OffsetBuffer::new(vec![0_i32, 2, 4].into());
+        let list = ListArray::new(
+            Arc::new(Field::new("item", ArrowDataType::Int32, true)),
+            offsets,
+            Arc::new(inner),
+            None,
+        );
+        let b = batch(vec![("arr", Arc::new(list) as ArrayRef)]);
+        let rt = RowType::new(vec![DataField::new(
+            "arr",
+            DataTypes::array(DataTypes::int()),
+            None,
+        )]);
+        let tb = TypedBatch::build(&b, &rt).expect("build");
+
+        match &tb.columns[0] {
+            TypedColumn::Array(_, element) => match element.as_ref() {
+                TypedColumn::Int(arr) => {
+                    assert_eq!(arr.len(), 4);
+                    assert_eq!(arr.value(0), 10);
+                    assert_eq!(arr.value(3), 40);
+                }
+                other => panic!(
+                    "expected Int element vector, got {:?}",
+                    other.outer_array().data_type()
+                ),
+            },
+            other => panic!("expected Array, got {:?}", other.outer_array().data_type()),
+        }
+    }
+
+    #[test]
+    fn recursive_row_builds_inner_batch() {
+        let fields = Fields::from(vec![
+            Field::new("x", ArrowDataType::Int32, true),
+            Field::new("y", ArrowDataType::Utf8, true),
+        ]);
+        let struct_arr = StructArray::new(
+            fields.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef,
+            ],
+            None,
+        );
+        let b = batch(vec![("nested", Arc::new(struct_arr) as ArrayRef)]);
+        let rt = RowType::new(vec![DataField::new(
+            "nested",
+            DataTypes::row(vec![
+                DataField::new("x", DataTypes::int(), None),
+                DataField::new("y", DataTypes::string(), None),
+            ]),
+            None,
+        )]);
+        let tb = TypedBatch::build(&b, &rt).expect("build");
+
+        match &tb.columns[0] {
+            TypedColumn::Row(_, inner) => {
+                assert_eq!(inner.num_rows, 2);
+                assert_eq!(inner.columns.len(), 2);
+                assert!(matches!(inner.columns[0], TypedColumn::Int(_)));
+                assert!(matches!(inner.columns[1], TypedColumn::String(_)));
+                assert_eq!(inner.columns[0].get_int(0).unwrap(), 1);
+                assert_eq!(inner.columns[1].get_string(1).unwrap(), "b");
+            }
+            other => panic!("expected Row, got {:?}", other.outer_array().data_type()),
+        }
+    }
+
+    #[test]
+    fn decimal_carries_arrow_scale() {
+        let arr = Decimal128Array::from(vec![12345_i128])
+            .with_precision_and_scale(10, 2)
+            .unwrap();
+        let b = batch(vec![("d", Arc::new(arr) as ArrayRef)]);
+        let rt = RowType::new(vec![DataField::new("d", DataTypes::decimal(10, 2), None)]);
+        let tb = TypedBatch::build(&b, &rt).expect("build");
+
+        match &tb.columns[0] {
+            TypedColumn::Decimal(_, arrow_scale) => assert_eq!(*arrow_scale, 2),
+            other => panic!(
+                "expected Decimal, got {:?}",
+                other.outer_array().data_type()
+            ),
+        }
+        let d = tb.columns[0].get_decimal(0, 10, 2).unwrap();
+        assert_eq!(d.precision(), 10);
+        assert_eq!(d.scale(), 2);
+        assert_eq!(d.to_unscaled_long().unwrap(), 12345);
+    }
+}

--- a/crates/fluss/src/row/column_writer.rs
+++ b/crates/fluss/src/row/column_writer.rs
@@ -26,7 +26,8 @@ use crate::row::datum::{
     MICROS_PER_MILLI, MILLIS_PER_SECOND, NANOS_PER_MILLI, append_decimal_to_builder,
     millis_nanos_to_micros, millis_nanos_to_nanos,
 };
-use crate::row::{FlussArray, FlussMap, InternalRow};
+use crate::row::view::{ArrayView, MapView, RowView};
+use crate::row::{DataGetters, InternalArray, InternalMap, InternalRow};
 use arrow::array::{
     ArrayBuilder, ArrayRef, BinaryBuilder, BooleanBuilder, Date32Builder, Decimal128Builder,
     FixedSizeBinaryBuilder, Float32Builder, Float64Builder, Int8Builder, Int16Builder,
@@ -459,14 +460,16 @@ impl ColumnWriter {
     /// Read one value from `row` at this writer's column position and append it
     /// directly to the concrete Arrow builder.
     #[inline]
-    pub fn write_field(&mut self, row: &dyn InternalRow) -> Result<()> {
+    pub fn write_field(&mut self, row: &dyn DataGetters) -> Result<()> {
         self.write_field_at(row, self.pos)
     }
 
     /// Read one value from `row` at position `pos` and append it
-    /// directly to the concrete Arrow builder.
+    /// directly to the concrete Arrow builder. Accepts any [`DataGetters`]
+    /// so array elements and row fields share the same writer surface
+    /// (no materialization when the source is a columnar slice).
     #[inline]
-    pub fn write_field_at(&mut self, row: &dyn InternalRow, pos: usize) -> Result<()> {
+    pub fn write_field_at(&mut self, row: &dyn DataGetters, pos: usize) -> Result<()> {
         if self.nullable && row.is_null_at(pos)? {
             self.append_null();
             return Ok(());
@@ -649,7 +652,7 @@ impl ColumnWriter {
     }
 
     #[inline]
-    fn write_non_null_at(&mut self, row: &dyn InternalRow, pos: usize) -> Result<()> {
+    fn write_non_null_at(&mut self, row: &dyn DataGetters, pos: usize) -> Result<()> {
         match &mut self.inner {
             TypedWriter::Bool(b) => {
                 b.append_value(row.get_boolean(pos)?);
@@ -831,55 +834,10 @@ impl ColumnWriter {
                 offsets,
                 validity,
             } => {
-                let array = row.get_array(pos)?;
-                let size = array.size();
-                match &mut element_writer.inner {
-                    TypedWriter::Struct {
-                        field_writers,
-                        validity: child_validity,
-                        row_type,
-                        ..
-                    } => {
-                        for i in 0..size {
-                            if array.is_null_at(i) {
-                                for child in field_writers.iter_mut() {
-                                    child.append_null();
-                                }
-                                child_validity.push(false);
-                            } else {
-                                let nested = array.get_row(i, row_type)?;
-                                for (j, child) in field_writers.iter_mut().enumerate() {
-                                    child.write_field_at(&nested, j)?;
-                                }
-                                child_validity.push(true);
-                            }
-                        }
-                    }
-                    TypedWriter::Map {
-                        key_writer,
-                        value_writer,
-                        key_type,
-                        value_type,
-                        offsets: child_offsets,
-                        validity: child_validity,
-                    } => {
-                        for i in 0..size {
-                            if array.is_null_at(i) {
-                                child_validity.push(false);
-                                let last = *child_offsets.last().unwrap();
-                                child_offsets.push(last);
-                            } else {
-                                let map = array.get_map(i, key_type, value_type)?;
-                                write_map_into(map, key_writer, value_writer, child_offsets)?;
-                                child_validity.push(true);
-                            }
-                        }
-                    }
-                    _ => {
-                        for i in 0..size {
-                            element_writer.write_field_at(&array, i)?;
-                        }
-                    }
+                let array_view = row.get_array(pos)?;
+                let size = array_view.size();
+                for i in 0..size {
+                    write_array_element_into_column(element_writer, &array_view, i)?;
                 }
                 let last = *offsets.last().unwrap();
                 offsets.push(
@@ -897,8 +855,7 @@ impl ColumnWriter {
                 validity,
                 ..
             } => {
-                let map = row.get_map(pos)?;
-                write_map_into(map, key_writer, value_writer, offsets)?;
+                write_map_into(row.get_map(pos)?, key_writer, value_writer, offsets)?;
                 validity.push(true);
                 Ok(())
             }
@@ -908,8 +865,14 @@ impl ColumnWriter {
                 ..
             } => {
                 let nested = row.get_row(pos)?;
+                // Zero-copy: ColumnarRow walks its TypedBatch in place, so the
+                // struct writer can pull fields without materializing.
+                let nested_ref: &dyn InternalRow = match &nested {
+                    RowView::Generic(g) => *g,
+                    RowView::Columnar(cr) => cr,
+                };
                 for (i, child) in field_writers.iter_mut().enumerate() {
-                    child.write_field_at(nested, i)?;
+                    child.write_field_at(nested_ref, i)?;
                 }
                 validity.push(true);
                 Ok(())
@@ -919,31 +882,42 @@ impl ColumnWriter {
 }
 
 fn write_map_into(
-    map: FlussMap,
+    map: MapView<'_>,
     key_writer: &mut ColumnWriter,
     value_writer: &mut ColumnWriter,
     offsets: &mut Vec<i32>,
 ) -> Result<()> {
-    let key_array = map.key_array();
-    let value_array = map.value_array();
-    for i in 0..map.size() {
-        write_array_element_into_column(key_writer, key_array, i)?;
-        write_array_element_into_column(value_writer, value_array, i)?;
+    let size = map.size();
+    let (key_view, value_view) = match map {
+        MapView::Binary(m) => (
+            ArrayView::Binary(m.key_array().clone()),
+            ArrayView::Binary(m.value_array().clone()),
+        ),
+        MapView::Columnar(cm) => (
+            ArrayView::Columnar(*cm.keys_slice()),
+            ArrayView::Columnar(*cm.values_slice()),
+        ),
+    };
+    for i in 0..size {
+        write_array_element_into_column(key_writer, &key_view, i)?;
+        write_array_element_into_column(value_writer, &value_view, i)?;
     }
     let last = *offsets.last().unwrap();
     offsets.push(
-        last + i32::try_from(map.size()).map_err(|_| RowConvertError {
-            message: format!("Map size {} exceeds i32 range", map.size()),
+        last + i32::try_from(size).map_err(|_| RowConvertError {
+            message: format!("Map size {size} exceeds i32 range"),
         })?,
     );
     Ok(())
 }
 
-// FlussArray carries no schema; nested row/map elements need the typed
-// inherent accessors (get_row/get_map with explicit types).
+/// Writes one element of `array` into `writer`. For nested ROW / MAP elements
+/// the source variant decides how to fetch the inner value: binary arrays
+/// need the inherent schema-carrying accessor; columnar slices walk the
+/// `TypedBatch` zero-copy.
 fn write_array_element_into_column(
     writer: &mut ColumnWriter,
-    array: &FlussArray,
+    array: &ArrayView<'_>,
     index: usize,
 ) -> Result<()> {
     match &mut writer.inner {
@@ -953,18 +927,32 @@ fn write_array_element_into_column(
             row_type,
             ..
         } => {
-            if array.is_null_at(index) {
+            if array.is_null_at(index)? {
                 for child in field_writers.iter_mut() {
                     child.append_null();
                 }
                 validity.push(false);
-            } else {
-                let nested = array.get_row(index, row_type)?;
-                for (j, child) in field_writers.iter_mut().enumerate() {
-                    child.write_field_at(&nested, j)?;
-                }
-                validity.push(true);
+                return Ok(());
             }
+            match array {
+                ArrayView::Binary(arr) => {
+                    let nested = arr.get_row(index, row_type)?;
+                    for (j, child) in field_writers.iter_mut().enumerate() {
+                        child.write_field_at(&nested, j)?;
+                    }
+                }
+                ArrayView::Columnar(slice) => {
+                    let nested = slice.get_row(index)?;
+                    let nested_ref: &dyn DataGetters = match &nested {
+                        RowView::Generic(g) => *g,
+                        RowView::Columnar(cr) => cr,
+                    };
+                    for (j, child) in field_writers.iter_mut().enumerate() {
+                        child.write_field_at(nested_ref, j)?;
+                    }
+                }
+            }
+            validity.push(true);
             Ok(())
         }
         TypedWriter::Map {
@@ -975,15 +963,20 @@ fn write_array_element_into_column(
             offsets,
             validity,
         } => {
-            if array.is_null_at(index) {
+            if array.is_null_at(index)? {
                 validity.push(false);
                 let last = *offsets.last().unwrap();
                 offsets.push(last);
-            } else {
-                let nested = array.get_map(index, key_type, value_type)?;
-                write_map_into(nested, key_writer, value_writer, offsets)?;
-                validity.push(true);
+                return Ok(());
             }
+            let nested = match array {
+                ArrayView::Binary(arr) => {
+                    MapView::Binary(arr.get_map(index, key_type, value_type)?)
+                }
+                ArrayView::Columnar(slice) => slice.get_map(index)?,
+            };
+            write_map_into(nested, key_writer, value_writer, offsets)?;
+            validity.push(true);
             Ok(())
         }
         _ => writer.write_field_at(array, index),
@@ -1077,14 +1070,21 @@ fn finish_map_array(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metadata::DataTypes;
+    use crate::metadata::{DataField, DataTypes, RowType};
     use crate::record::to_arrow_type;
     use crate::row::binary_array::FlussArrayWriter;
     use crate::row::binary_map::FlussMapWriter;
-    use crate::row::{Date, Datum, Decimal, GenericRow, Time, TimestampLtz, TimestampNtz};
+    use crate::row::column::ColumnarRow;
+    use crate::row::view::ArrayView;
+    use crate::row::{
+        DataGetters, Date, Datum, Decimal, GenericRow, Time, TimestampLtz, TimestampNtz,
+    };
     use arrow::array::*;
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{Field, Fields, Schema};
     use bigdecimal::BigDecimal;
     use std::str::FromStr;
+    use std::sync::Arc;
 
     /// Helper: create a ColumnWriter from a Fluss DataType, deriving the Arrow type automatically.
     fn writer_for(fluss_type: &DataType, capacity: usize) -> ColumnWriter {
@@ -1398,5 +1398,212 @@ mod tests {
 
         assert_eq!(map_arr.len(), 1);
         assert!(map_arr.is_null(0));
+    }
+
+    #[test]
+    fn writes_row_with_nested_array_from_columnar_input() {
+        // Two outer rows of ROW<x: INT, y: ARRAY<INT>>:
+        //   { x: 1, y: [10, 20] }
+        //   { x: 2, y: [30] }
+        let x = Int32Array::from(vec![1, 2]);
+        let y_values = Int32Array::from(vec![10, 20, 30]);
+        let y_offsets = OffsetBuffer::new(vec![0_i32, 2, 3].into());
+        let y_list = ListArray::new(
+            Arc::new(Field::new("item", ArrowDataType::Int32, true)),
+            y_offsets,
+            Arc::new(y_values),
+            None,
+        );
+        let row_fields = Fields::from(vec![
+            Field::new("x", ArrowDataType::Int32, true),
+            Field::new(
+                "y",
+                ArrowDataType::List(Arc::new(Field::new("item", ArrowDataType::Int32, true))),
+                true,
+            ),
+        ]);
+        let struct_arr = StructArray::new(
+            row_fields.clone(),
+            vec![Arc::new(x) as ArrayRef, Arc::new(y_list) as ArrayRef],
+            None,
+        );
+        let rb = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "nested",
+                ArrowDataType::Struct(row_fields.clone()),
+                true,
+            )])),
+            vec![Arc::new(struct_arr) as ArrayRef],
+        )
+        .unwrap();
+
+        let nested_fields = vec![
+            DataField::new("x", DataTypes::int(), None),
+            DataField::new("y", DataTypes::array(DataTypes::int()), None),
+        ];
+        let outer_row_type = Arc::new(RowType::with_data_types(vec![DataTypes::row(
+            nested_fields.clone(),
+        )]));
+        let mut row = ColumnarRow::new(Arc::new(rb), outer_row_type, 0, None).unwrap();
+
+        let nested_fluss = DataTypes::row(nested_fields);
+        let nested_arrow = to_arrow_type(&nested_fluss).unwrap();
+        let mut writer = ColumnWriter::create(&nested_fluss, &nested_arrow, 0, 2).unwrap();
+
+        for i in 0..2 {
+            row.set_row_id(i);
+            writer.write_field(&row).unwrap();
+        }
+
+        let result = writer.finish();
+        let result_struct = result.as_any().downcast_ref::<StructArray>().unwrap();
+        assert_eq!(result_struct.len(), 2);
+
+        let x_col = result_struct
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(x_col.value(0), 1);
+        assert_eq!(x_col.value(1), 2);
+
+        let y_col = result_struct
+            .column(1)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        let y0 = y_col.value(0);
+        let y0_ints = y0.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(y0_ints.len(), 2);
+        assert_eq!(y0_ints.value(0), 10);
+        assert_eq!(y0_ints.value(1), 20);
+        let y1 = y_col.value(1);
+        let y1_ints = y1.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(y1_ints.len(), 1);
+        assert_eq!(y1_ints.value(0), 30);
+    }
+
+    #[test]
+    fn writes_array_of_primitives_from_columnar_input_without_materializing() {
+        // [ [10, 20], [30] ]
+        let values = Int32Array::from(vec![10, 20, 30]);
+        let offsets = OffsetBuffer::new(vec![0_i32, 2, 3].into());
+        let list = ListArray::new(
+            Arc::new(Field::new("item", ArrowDataType::Int32, true)),
+            offsets,
+            Arc::new(values),
+            None,
+        );
+        let rb = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "arr",
+                list.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(list) as ArrayRef],
+        )
+        .unwrap();
+
+        let arr_fluss = DataTypes::array(DataTypes::int());
+        let outer_row_type = Arc::new(RowType::with_data_types(vec![arr_fluss.clone()]));
+        let mut row = ColumnarRow::new(Arc::new(rb), outer_row_type, 0, None).unwrap();
+
+        match row.get_array(0).unwrap() {
+            ArrayView::Columnar(_) => {}
+            ArrayView::Binary(_) => panic!("scan-output array must be Columnar"),
+        }
+
+        let arrow_ty = to_arrow_type(&arr_fluss).unwrap();
+        let mut writer = ColumnWriter::create(&arr_fluss, &arrow_ty, 0, 2).unwrap();
+
+        for i in 0..2 {
+            row.set_row_id(i);
+            writer.write_field(&row).unwrap();
+        }
+
+        let result = writer.finish();
+        let result_list = result.as_any().downcast_ref::<ListArray>().unwrap();
+        assert_eq!(result_list.len(), 2);
+        let r0 = result_list.value(0);
+        let r0_ints = r0.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(r0_ints.len(), 2);
+        assert_eq!(r0_ints.value(0), 10);
+        assert_eq!(r0_ints.value(1), 20);
+        let r1 = result_list.value(1);
+        let r1_ints = r1.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(r1_ints.len(), 1);
+        assert_eq!(r1_ints.value(0), 30);
+    }
+
+    #[test]
+    fn writes_map_of_primitives_from_columnar_input_without_materializing() {
+        // { "a" -> 1, "b" -> 2 }
+        let keys = StringArray::from(vec!["a", "b"]);
+        let values = Int32Array::from(vec![1, 2]);
+        let entries_fields = arrow_schema::Fields::from(vec![
+            Field::new("keys", ArrowDataType::Utf8, false),
+            Field::new("values", ArrowDataType::Int32, true),
+        ]);
+        let entries = StructArray::new(
+            entries_fields.clone(),
+            vec![Arc::new(keys) as ArrayRef, Arc::new(values) as ArrayRef],
+            None,
+        );
+        let offsets = OffsetBuffer::new(vec![0_i32, 2].into());
+        let map = MapArray::new(
+            Arc::new(Field::new(
+                "entries",
+                ArrowDataType::Struct(entries_fields),
+                false,
+            )),
+            offsets,
+            entries,
+            None,
+            false,
+        );
+        let rb = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "m",
+                map.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(map) as ArrayRef],
+        )
+        .unwrap();
+
+        let map_fluss = DataTypes::map(DataTypes::string(), DataTypes::int());
+        let outer_row_type = Arc::new(RowType::with_data_types(vec![map_fluss.clone()]));
+        let row = ColumnarRow::new(Arc::new(rb), outer_row_type, 0, None).unwrap();
+
+        match row.get_map(0).unwrap() {
+            MapView::Columnar(_) => {}
+            MapView::Binary(_) => panic!("scan-output map must be Columnar"),
+        }
+
+        let arrow_ty = to_arrow_type(&map_fluss).unwrap();
+        let mut writer = ColumnWriter::create(&map_fluss, &arrow_ty, 0, 1).unwrap();
+
+        writer.write_field(&row).unwrap();
+
+        let result = writer.finish();
+        let result_map = result.as_any().downcast_ref::<MapArray>().unwrap();
+        assert_eq!(result_map.len(), 1);
+        let entries = result_map.value(0);
+        let entries_struct = entries.as_any().downcast_ref::<StructArray>().unwrap();
+        let key_col = entries_struct
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let val_col = entries_struct
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(key_col.len(), 2);
+        assert_eq!(key_col.value(0), "a");
+        assert_eq!(key_col.value(1), "b");
+        assert_eq!(val_col.value(0), 1);
+        assert_eq!(val_col.value(1), 2);
     }
 }

--- a/crates/fluss/src/row/columnar.rs
+++ b/crates/fluss/src/row/columnar.rs
@@ -1,0 +1,364 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Zero-copy slice views over a typed Arrow batch. An `ARRAY` cell is
+//! `(element column, start, length)`; a `MAP` is two parallel slices over
+//! the typed key/value vectors.
+
+use crate::error::Error::IllegalArgument;
+use crate::error::Result;
+use crate::row::Decimal;
+use crate::row::column::ColumnarRow;
+use crate::row::column_vector::TypedColumn;
+use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz};
+use crate::row::view::{ArrayView, MapView, RowView};
+use crate::row::{DataGetters, InternalArray, InternalMap};
+use std::sync::Arc;
+
+/// A slice of an element `TypedColumn` representing one `ARRAY` cell.
+#[derive(Debug, Clone, Copy)]
+pub struct ColumnarArray<'a> {
+    element: &'a TypedColumn,
+    start: usize,
+    length: usize,
+}
+
+impl<'a> ColumnarArray<'a> {
+    pub(crate) fn new(element: &'a TypedColumn, start: usize, length: usize) -> Self {
+        Self {
+            element,
+            start,
+            length,
+        }
+    }
+
+    /// The element-level `TypedColumn` this slice borrows from.
+    pub(crate) fn element(&self) -> &'a TypedColumn {
+        self.element
+    }
+
+    fn absolute_index(&self, pos: usize) -> Result<usize> {
+        if pos >= self.length {
+            return Err(IllegalArgument {
+                message: format!(
+                    "columnar array index out of bounds: pos={pos}, length={}",
+                    self.length
+                ),
+            });
+        }
+        Ok(self.start + pos)
+    }
+}
+
+impl InternalArray for ColumnarArray<'_> {
+    fn size(&self) -> usize {
+        self.length
+    }
+}
+
+impl DataGetters for ColumnarArray<'_> {
+    fn is_null_at(&self, pos: usize) -> Result<bool> {
+        let abs = self.absolute_index(pos)?;
+        Ok(self.element.is_null_at(abs))
+    }
+
+    fn get_boolean(&self, pos: usize) -> Result<bool> {
+        self.element.get_boolean(self.absolute_index(pos)?)
+    }
+    fn get_byte(&self, pos: usize) -> Result<i8> {
+        self.element.get_byte(self.absolute_index(pos)?)
+    }
+    fn get_short(&self, pos: usize) -> Result<i16> {
+        self.element.get_short(self.absolute_index(pos)?)
+    }
+    fn get_int(&self, pos: usize) -> Result<i32> {
+        self.element.get_int(self.absolute_index(pos)?)
+    }
+    fn get_long(&self, pos: usize) -> Result<i64> {
+        self.element.get_long(self.absolute_index(pos)?)
+    }
+    fn get_float(&self, pos: usize) -> Result<f32> {
+        self.element.get_float(self.absolute_index(pos)?)
+    }
+    fn get_double(&self, pos: usize) -> Result<f64> {
+        self.element.get_double(self.absolute_index(pos)?)
+    }
+
+    fn get_char(&self, pos: usize, _length: usize) -> Result<&str> {
+        self.element.get_char(self.absolute_index(pos)?)
+    }
+    fn get_string(&self, pos: usize) -> Result<&str> {
+        self.element.get_string(self.absolute_index(pos)?)
+    }
+
+    fn get_decimal(&self, pos: usize, precision: usize, scale: usize) -> Result<Decimal> {
+        self.element
+            .get_decimal(self.absolute_index(pos)?, precision as u32, scale as u32)
+    }
+
+    fn get_date(&self, pos: usize) -> Result<Date> {
+        self.element.get_date(self.absolute_index(pos)?)
+    }
+    fn get_time(&self, pos: usize) -> Result<Time> {
+        self.element.get_time(self.absolute_index(pos)?)
+    }
+    fn get_timestamp_ntz(&self, pos: usize, _precision: u32) -> Result<TimestampNtz> {
+        self.element.get_timestamp_ntz(self.absolute_index(pos)?)
+    }
+    fn get_timestamp_ltz(&self, pos: usize, _precision: u32) -> Result<TimestampLtz> {
+        self.element.get_timestamp_ltz(self.absolute_index(pos)?)
+    }
+
+    fn get_binary(&self, pos: usize, _length: usize) -> Result<&[u8]> {
+        self.element.get_binary(self.absolute_index(pos)?)
+    }
+    fn get_bytes(&self, pos: usize) -> Result<&[u8]> {
+        self.element.get_bytes(self.absolute_index(pos)?)
+    }
+
+    fn get_array(&self, pos: usize) -> Result<ArrayView<'_>> {
+        let abs = self.absolute_index(pos)?;
+        match self.element {
+            TypedColumn::Array(list_arr, inner) => {
+                let start = list_arr.value_offsets()[abs] as usize;
+                let end = list_arr.value_offsets()[abs + 1] as usize;
+                Ok(ArrayView::Columnar(ColumnarArray::new(
+                    inner.as_ref(),
+                    start,
+                    end - start,
+                )))
+            }
+            other => Err(IllegalArgument {
+                message: format!("expected ARRAY element at position {pos}, got {other:?}"),
+            }),
+        }
+    }
+
+    fn get_map(&self, pos: usize) -> Result<MapView<'_>> {
+        let abs = self.absolute_index(pos)?;
+        match self.element {
+            TypedColumn::Map(map_arr, keys, values) => {
+                let start = map_arr.value_offsets()[abs] as usize;
+                let end = map_arr.value_offsets()[abs + 1] as usize;
+                Ok(MapView::Columnar(ColumnarMap::new(
+                    keys.as_ref(),
+                    values.as_ref(),
+                    start,
+                    end - start,
+                )))
+            }
+            other => Err(IllegalArgument {
+                message: format!("expected MAP element at position {pos}, got {other:?}"),
+            }),
+        }
+    }
+
+    fn get_row(&self, pos: usize) -> Result<RowView<'_>> {
+        let abs = self.absolute_index(pos)?;
+        match self.element {
+            TypedColumn::Row(_, inner_batch) => Ok(RowView::Columnar(
+                ColumnarRow::from_typed_batch(Arc::clone(inner_batch), abs),
+            )),
+            other => Err(IllegalArgument {
+                message: format!("expected ROW element at position {pos}, got {other:?}"),
+            }),
+        }
+    }
+}
+
+/// Two parallel slices over the typed key/value vectors. Map keys are
+/// non-nullable per Fluss spec.
+#[derive(Debug, Clone, Copy)]
+pub struct ColumnarMap<'a> {
+    keys: ColumnarArray<'a>,
+    values: ColumnarArray<'a>,
+}
+
+impl<'a> ColumnarMap<'a> {
+    pub(crate) fn new(
+        keys_column: &'a TypedColumn,
+        values_column: &'a TypedColumn,
+        start: usize,
+        length: usize,
+    ) -> Self {
+        Self {
+            keys: ColumnarArray::new(keys_column, start, length),
+            values: ColumnarArray::new(values_column, start, length),
+        }
+    }
+
+    pub(crate) fn keys_slice(&self) -> &ColumnarArray<'a> {
+        &self.keys
+    }
+
+    pub(crate) fn values_slice(&self) -> &ColumnarArray<'a> {
+        &self.values
+    }
+}
+
+impl InternalMap for ColumnarMap<'_> {
+    fn size(&self) -> usize {
+        self.keys.size()
+    }
+
+    fn key_array(&self) -> &dyn InternalArray {
+        &self.keys
+    }
+
+    fn value_array(&self) -> &dyn InternalArray {
+        &self.values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::{DataField, DataTypes, RowType};
+    use crate::row::column_vector::TypedBatch;
+    use arrow::array::{
+        Array, ArrayRef, Int32Array, ListArray, MapArray, RecordBatch, StringArray, StructArray,
+    };
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema};
+    use std::sync::Arc;
+
+    fn list_int_batch() -> (ListArray, Arc<TypedBatch>) {
+        // ARRAY<INT>: two rows — [10,20], [30,40,50]
+        let values = Int32Array::from(vec![10, 20, 30, 40, 50]);
+        let offsets = OffsetBuffer::new(vec![0_i32, 2, 5].into());
+        let list = ListArray::new(
+            Arc::new(Field::new("item", ArrowDataType::Int32, true)),
+            offsets,
+            Arc::new(values),
+            None,
+        );
+        let rb = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "arr",
+                list.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(list.clone()) as ArrayRef],
+        )
+        .expect("batch");
+        let rt = RowType::new(vec![DataField::new(
+            "arr",
+            DataTypes::array(DataTypes::int()),
+            None,
+        )]);
+        (list, Arc::new(TypedBatch::build(&rb, &rt).expect("build")))
+    }
+
+    #[test]
+    fn columnar_array_reads_a_slice_of_the_element_vector() {
+        let (list, tb) = list_int_batch();
+
+        let element = match &tb.columns[0] {
+            TypedColumn::Array(_, e) => e.as_ref(),
+            _ => unreachable!(),
+        };
+
+        // Row 1 — slice [30, 40, 50] of the flat element vector.
+        let start = list.value_offsets()[1] as usize;
+        let end = list.value_offsets()[2] as usize;
+        let arr = ColumnarArray::new(element, start, end - start);
+
+        assert_eq!(arr.size(), 3);
+        assert!(!arr.is_null_at(0).unwrap());
+        assert_eq!(arr.get_int(0).unwrap(), 30);
+        assert_eq!(arr.get_int(1).unwrap(), 40);
+        assert_eq!(arr.get_int(2).unwrap(), 50);
+    }
+
+    #[test]
+    fn columnar_array_out_of_bounds_is_clear_error() {
+        let (list, tb) = list_int_batch();
+        let element = match &tb.columns[0] {
+            TypedColumn::Array(_, e) => e.as_ref(),
+            _ => unreachable!(),
+        };
+        let start = list.value_offsets()[0] as usize;
+        let end = list.value_offsets()[1] as usize;
+        let arr = ColumnarArray::new(element, start, end - start);
+
+        let err = arr.get_int(5).unwrap_err().to_string();
+        assert!(err.contains("out of bounds"), "{err}");
+    }
+
+    fn map_string_int_batch() -> (MapArray, Arc<TypedBatch>) {
+        // MAP<STRING, INT>: one row — {"a": 1, "b": 2}
+        let keys = StringArray::from(vec!["a", "b"]);
+        let values = Int32Array::from(vec![1, 2]);
+        let entries_fields = Fields::from(vec![
+            Field::new("keys", ArrowDataType::Utf8, false),
+            Field::new("values", ArrowDataType::Int32, true),
+        ]);
+        let entries = StructArray::new(
+            entries_fields.clone(),
+            vec![Arc::new(keys) as ArrayRef, Arc::new(values) as ArrayRef],
+            None,
+        );
+        let offsets = OffsetBuffer::new(vec![0_i32, 2].into());
+        let map = MapArray::new(
+            Arc::new(Field::new(
+                "entries",
+                ArrowDataType::Struct(entries_fields),
+                false,
+            )),
+            offsets,
+            entries,
+            None,
+            false,
+        );
+        let rb = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "m",
+                map.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(map.clone()) as ArrayRef],
+        )
+        .expect("batch");
+        let rt = RowType::new(vec![DataField::new(
+            "m",
+            DataTypes::map(DataTypes::string(), DataTypes::int()),
+            None,
+        )]);
+        (map, Arc::new(TypedBatch::build(&rb, &rt).expect("build")))
+    }
+
+    #[test]
+    fn columnar_map_exposes_key_and_value_slices() {
+        let (map, tb) = map_string_int_batch();
+        let (key_col, value_col) = match &tb.columns[0] {
+            TypedColumn::Map(_, k, v) => (k.as_ref(), v.as_ref()),
+            _ => unreachable!(),
+        };
+        let start = map.value_offsets()[0] as usize;
+        let end = map.value_offsets()[1] as usize;
+        let cm = ColumnarMap::new(key_col, value_col, start, end - start);
+
+        assert_eq!(cm.size(), 2);
+        let keys = cm.key_array();
+        let values = cm.value_array();
+        assert_eq!(keys.size(), 2);
+        assert_eq!(keys.get_string(0).unwrap(), "a");
+        assert_eq!(keys.get_string(1).unwrap(), "b");
+        assert_eq!(values.get_int(0).unwrap(), 1);
+        assert_eq!(values.get_int(1).unwrap(), 2);
+    }
+}

--- a/crates/fluss/src/row/compacted/compacted_row.rs
+++ b/crates/fluss/src/row/compacted/compacted_row.rs
@@ -19,11 +19,10 @@ use crate::client::WriteFormat;
 use crate::error::Error::IllegalArgument;
 use crate::error::Result;
 use crate::metadata::RowType;
-use crate::row::binary_array::FlussArray;
-use crate::row::binary_map::FlussMap;
 use crate::row::compacted::compacted_row_reader::{CompactedRowDeserializer, CompactedRowReader};
 use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz};
-use crate::row::{Decimal, GenericRow, InternalRow};
+use crate::row::view::{ArrayView, MapView, RowView};
+use crate::row::{DataGetters, Decimal, GenericRow, InternalRow};
 use std::sync::{Arc, OnceLock};
 
 pub fn calculate_bit_set_width_in_bytes(arity: usize) -> usize {
@@ -93,6 +92,16 @@ impl<'a> InternalRow for CompactedRow<'a> {
         self.arity
     }
 
+    fn as_encoded_bytes(&self, write_format: WriteFormat) -> Option<&[u8]> {
+        match write_format {
+            WriteFormat::CompactedKv => Some(self.as_bytes()),
+            WriteFormat::ArrowLog => None,
+            WriteFormat::CompactedLog => None,
+        }
+    }
+}
+
+impl<'a> DataGetters for CompactedRow<'a> {
     fn is_null_at(&self, pos: usize) -> Result<bool> {
         let fields = self.deserializer.get_row_type().fields();
         if pos >= fields.len() {
@@ -170,24 +179,16 @@ impl<'a> InternalRow for CompactedRow<'a> {
         self.decoded_row()?.get_bytes(pos)
     }
 
-    fn get_array(&self, pos: usize) -> Result<FlussArray> {
+    fn get_array(&self, pos: usize) -> Result<ArrayView<'_>> {
         self.decoded_row()?.get_array(pos)
     }
 
-    fn get_map(&self, pos: usize) -> Result<FlussMap> {
+    fn get_map(&self, pos: usize) -> Result<MapView<'_>> {
         self.decoded_row()?.get_map(pos)
     }
 
-    fn get_row(&self, pos: usize) -> Result<&GenericRow<'_>> {
+    fn get_row(&self, pos: usize) -> Result<RowView<'_>> {
         self.decoded_row()?.get_row(pos)
-    }
-
-    fn as_encoded_bytes(&self, write_format: WriteFormat) -> Option<&[u8]> {
-        match write_format {
-            WriteFormat::CompactedKv => Some(self.as_bytes()),
-            WriteFormat::ArrowLog => None,
-            WriteFormat::CompactedLog => None,
-        }
     }
 }
 
@@ -198,6 +199,7 @@ mod tests {
     use crate::row::binary::BinaryWriter;
     use crate::row::binary_array::FlussArrayWriter;
     use crate::row::binary_map::FlussMapWriter;
+    use crate::row::{InternalArray, InternalMap};
 
     use crate::metadata::{
         BigIntType, BooleanType, BytesType, DataType, DoubleType, FloatType, IntType, SmallIntType,
@@ -424,10 +426,10 @@ mod tests {
 
         let read_arr = row.get_array(0).unwrap();
         assert_eq!(read_arr.size(), 3);
-        assert!(!read_arr.is_null_at(0));
+        assert!(!read_arr.is_null_at(0).unwrap());
         assert_eq!(read_arr.get_int(0).unwrap(), 10);
-        assert!(read_arr.is_null_at(1));
-        assert!(!read_arr.is_null_at(2));
+        assert!(read_arr.is_null_at(1).unwrap());
+        assert!(!read_arr.is_null_at(2).unwrap());
         assert_eq!(read_arr.get_int(2).unwrap(), 30);
     }
 

--- a/crates/fluss/src/row/compacted/compacted_row_reader.rs
+++ b/crates/fluss/src/row/compacted/compacted_row_reader.rs
@@ -365,7 +365,7 @@ mod row_type_tests {
     use crate::row::compacted::compacted_row_writer::CompactedRowWriter;
     use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz};
     use crate::row::field_getter::FieldGetter;
-    use crate::row::{Datum, GenericRow, InternalRow};
+    use crate::row::{DataGetters, Datum, GenericRow, InternalRow};
 
     fn round_trip<F>(outer_row_type: &RowType, outer_row: &GenericRow, verify: F)
     where

--- a/crates/fluss/src/row/datum.rs
+++ b/crates/fluss/src/row/datum.rs
@@ -706,7 +706,7 @@ pub(crate) fn read_datum_from_fluss_array<'a>(
     Ok(getter.get_field(arr)?.into_owned())
 }
 
-fn internal_row_to_owned_generic(
+pub(crate) fn internal_row_to_owned_generic(
     row: &dyn InternalRow,
     row_type: &RowType,
 ) -> Result<GenericRow<'static>> {
@@ -832,7 +832,7 @@ fn append_generic_row_to_struct_builder(
         })?;
 
     let row_type = match fluss_type {
-        crate::metadata::DataType::Row(rt) => rt,
+        DataType::Row(rt) => rt,
         _ => {
             return Err(RowConvertError {
                 message: format!("Expected Row Fluss type for Row datum, got: {fluss_type:?}"),
@@ -1475,9 +1475,9 @@ mod tests {
 #[cfg(test)]
 mod timestamp_tests {
     use super::*;
-    use crate::metadata::{DataField, DataTypes};
+    use crate::metadata::{DataField, DataTypes, RowType};
     use crate::record::to_arrow_type;
-    use crate::row::InternalRow;
+    use crate::row::DataGetters;
     use crate::row::column::ColumnarRow;
     use arrow::array::{RecordBatch, StructArray, StructBuilder};
     use arrow::datatypes::{Field, Fields, Schema};
@@ -1529,7 +1529,7 @@ mod timestamp_tests {
 
     #[test]
     fn test_row_arrow_struct_round_trip() {
-        let row_type = crate::metadata::RowType::new(vec![
+        let row_type = RowType::new(vec![
             DataField::new("x", DataTypes::int(), None),
             DataField::new("label", DataTypes::string(), None),
         ]);
@@ -1571,7 +1571,14 @@ mod timestamp_tests {
             RecordBatch::try_new(schema, vec![Arc::new(struct_array)]).expect("record batch"),
         );
 
-        let mut columnar = ColumnarRow::new(batch, Arc::new(row_type), 0, None);
+        // Outer batch has one column ("nested") whose type is ROW<x INT, label STRING>.
+        let outer_row_type = RowType::new(vec![DataField::new(
+            "nested",
+            DataType::Row(row_type),
+            None,
+        )]);
+        let mut columnar =
+            ColumnarRow::new(batch, Arc::new(outer_row_type), 0, None).expect("ColumnarRow");
 
         let nested = columnar.get_row(0).expect("get_row 0");
         assert_eq!(nested.get_int(0).unwrap(), 42);

--- a/crates/fluss/src/row/field_getter.rs
+++ b/crates/fluss/src/row/field_getter.rs
@@ -88,7 +88,10 @@ impl FieldGetter {
                 key_type: m.key_type().clone(),
                 value_type: m.value_type().clone(),
             },
-            DataType::Row(_) => InnerFieldGetter::Row { pos },
+            DataType::Row(rt) => InnerFieldGetter::Row {
+                pos,
+                row_type: rt.clone(),
+            },
         };
 
         if data_type.is_nullable() {
@@ -165,6 +168,9 @@ pub enum InnerFieldGetter {
     },
     Row {
         pos: usize,
+        /// Schema needed to materialize a columnar `RowView` back into an
+        /// owned `GenericRow` for `Datum::Row`.
+        row_type: RowType,
     },
 }
 
@@ -195,9 +201,13 @@ impl InnerFieldGetter {
             InnerFieldGetter::TimestampLtz { pos, precision } => {
                 Datum::TimestampLtz(row.get_timestamp_ltz(*pos, *precision)?)
             }
-            InnerFieldGetter::Array { pos } => Datum::Array(row.get_array(*pos)?),
-            InnerFieldGetter::Map { pos, .. } => Datum::Map(row.get_map(*pos)?),
-            InnerFieldGetter::Row { pos } => Datum::Row(Box::new(row.get_row(*pos)?.clone())),
+            InnerFieldGetter::Array { pos } => {
+                Datum::Array(row.get_array(*pos)?.try_into_binary()?)
+            }
+            InnerFieldGetter::Map { pos, .. } => Datum::Map(row.get_map(*pos)?.try_into_binary()?),
+            InnerFieldGetter::Row { pos, row_type } => {
+                Datum::Row(Box::new(row.get_row(*pos)?.try_into_generic(row_type)?))
+            }
         })
     }
 
@@ -221,7 +231,7 @@ impl InnerFieldGetter {
             | Self::TimestampLtz { pos, .. }
             | Self::Array { pos }
             | Self::Map { pos, .. }
-            | Self::Row { pos } => *pos,
+            | Self::Row { pos, .. } => *pos,
         }
     }
 }

--- a/crates/fluss/src/row/fixed_schema_decoder.rs
+++ b/crates/fluss/src/row/fixed_schema_decoder.rs
@@ -79,9 +79,9 @@ mod tests {
     use super::*;
     use crate::metadata::{Column, DataTypes, Schema};
     use crate::record::kv::SCHEMA_ID_LENGTH;
-    use crate::row::InternalRow;
     use crate::row::binary::BinaryWriter;
     use crate::row::compacted::CompactedRowWriter;
+    use crate::row::{DataGetters, InternalRow};
 
     fn schema_with_ids(columns: &[(i32, &str, crate::metadata::DataType)]) -> Schema {
         let cols: Vec<Column> = columns

--- a/crates/fluss/src/row/lookup_row.rs
+++ b/crates/fluss/src/row/lookup_row.rs
@@ -24,7 +24,8 @@ use crate::error::Result;
 use crate::row::compacted::CompactedRow;
 use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz};
 use crate::row::projected_row::ProjectedRow;
-use crate::row::{Decimal, FlussArray, FlussMap, GenericRow, InternalRow};
+use crate::row::view::{ArrayView, MapView, RowView};
+use crate::row::{DataGetters, Decimal, InternalRow};
 
 pub struct LookupRow<'a> {
     inner: Inner<'a>,
@@ -62,6 +63,13 @@ impl<'a> InternalRow for LookupRow<'a> {
     fn get_field_count(&self) -> usize {
         delegate!(self, get_field_count)
     }
+
+    fn as_encoded_bytes(&self, write_format: WriteFormat) -> Option<&[u8]> {
+        delegate!(self, as_encoded_bytes, write_format)
+    }
+}
+
+impl<'a> DataGetters for LookupRow<'a> {
     fn is_null_at(&self, pos: usize) -> Result<bool> {
         delegate!(self, is_null_at, pos)
     }
@@ -113,16 +121,13 @@ impl<'a> InternalRow for LookupRow<'a> {
     fn get_bytes(&self, pos: usize) -> Result<&[u8]> {
         delegate!(self, get_bytes, pos)
     }
-    fn get_array(&self, pos: usize) -> Result<FlussArray> {
+    fn get_array(&self, pos: usize) -> Result<ArrayView<'_>> {
         delegate!(self, get_array, pos)
     }
-    fn get_map(&self, pos: usize) -> Result<FlussMap> {
+    fn get_map(&self, pos: usize) -> Result<MapView<'_>> {
         delegate!(self, get_map, pos)
     }
-    fn get_row(&self, pos: usize) -> Result<&GenericRow<'_>> {
+    fn get_row(&self, pos: usize) -> Result<RowView<'_>> {
         delegate!(self, get_row, pos)
-    }
-    fn as_encoded_bytes(&self, write_format: WriteFormat) -> Option<&[u8]> {
-        delegate!(self, as_encoded_bytes, write_format)
     }
 }

--- a/crates/fluss/src/row/mod.rs
+++ b/crates/fluss/src/row/mod.rs
@@ -18,6 +18,9 @@
 pub mod binary_array;
 pub mod binary_map;
 mod column;
+pub(crate) mod column_vector;
+pub mod columnar;
+pub mod view;
 
 pub(crate) mod datum;
 mod decimal;
@@ -46,6 +49,7 @@ pub use lookup_row::LookupRow;
 pub(crate) use projected_row::ProjectedRow;
 pub use row_decoder::{CompactedRowDecoder, RowDecoder, RowDecoderFactory};
 use serde::Serialize;
+pub use view::{ArrayView, MapView, RowView};
 
 pub struct BinaryRow<'a> {
     data: BinaryDataWrapper<'a>,
@@ -69,84 +73,74 @@ impl<'a> BinaryRow<'a> {
 use crate::error::Error::IllegalArgument;
 use crate::error::Result;
 
-pub trait InternalRow: Send + Sync {
-    /// Returns the number of fields in this row
-    fn get_field_count(&self) -> usize;
-
-    /// Returns true if the element is null at the given position
+/// Positional typed reads shared by rows and arrays. Lets one writer accept
+/// either shape without materializing.
+pub trait DataGetters: Send + Sync {
     fn is_null_at(&self, pos: usize) -> Result<bool>;
 
-    /// Returns the boolean value at the given position
     fn get_boolean(&self, pos: usize) -> Result<bool>;
-
-    /// Returns the byte value at the given position
     fn get_byte(&self, pos: usize) -> Result<i8>;
-
-    /// Returns the short value at the given position
     fn get_short(&self, pos: usize) -> Result<i16>;
-
-    /// Returns the integer value at the given position
     fn get_int(&self, pos: usize) -> Result<i32>;
-
-    /// Returns the long value at the given position
     fn get_long(&self, pos: usize) -> Result<i64>;
-
-    /// Returns the float value at the given position
     fn get_float(&self, pos: usize) -> Result<f32>;
-
-    /// Returns the double value at the given position
     fn get_double(&self, pos: usize) -> Result<f64>;
-
-    /// Returns the string value at the given position with fixed length
     fn get_char(&self, pos: usize, length: usize) -> Result<&str>;
-
-    /// Returns the string value at the given position
     fn get_string(&self, pos: usize) -> Result<&str>;
-
-    /// Returns the decimal value at the given position
     fn get_decimal(&self, pos: usize, precision: usize, scale: usize) -> Result<Decimal>;
-
-    /// Returns the date value at the given position (date as days since epoch)
     fn get_date(&self, pos: usize) -> Result<Date>;
-
-    /// Returns the time value at the given position (time as milliseconds since midnight)
     fn get_time(&self, pos: usize) -> Result<Time>;
-
-    /// Returns the timestamp value at the given position (timestamp without timezone)
-    ///
-    /// The precision is required to determine whether the timestamp value was stored
-    /// in a compact representation (precision <= 3) or with nanosecond precision.
     fn get_timestamp_ntz(&self, pos: usize, precision: u32) -> Result<TimestampNtz>;
-
-    /// Returns the timestamp value at the given position (timestamp with local timezone)
-    ///
-    /// The precision is required to determine whether the timestamp value was stored
-    /// in a compact representation (precision <= 3) or with nanosecond precision.
     fn get_timestamp_ltz(&self, pos: usize, precision: u32) -> Result<TimestampLtz>;
-
-    /// Returns the binary value at the given position with fixed length
     fn get_binary(&self, pos: usize, length: usize) -> Result<&[u8]>;
-
-    /// Returns the binary value at the given position
     fn get_bytes(&self, pos: usize) -> Result<&[u8]>;
 
-    /// Returns the array value at the given position
-    fn get_array(&self, pos: usize) -> Result<FlussArray>;
+    fn get_array(&self, pos: usize) -> Result<view::ArrayView<'_>> {
+        Err(IllegalArgument {
+            message: format!("get_array not supported at position {pos}"),
+        })
+    }
 
-    /// Returns the map value at the given position
-    fn get_map(&self, pos: usize) -> Result<FlussMap>;
+    fn get_map(&self, pos: usize) -> Result<view::MapView<'_>> {
+        Err(IllegalArgument {
+            message: format!("get_map not supported at position {pos}"),
+        })
+    }
 
-    /// Returns the nested row value at the given position
-    fn get_row(&self, pos: usize) -> Result<&GenericRow<'_>> {
+    fn get_row(&self, pos: usize) -> Result<view::RowView<'_>> {
         Err(IllegalArgument {
             message: format!("get_row not supported at position {pos}"),
         })
     }
+}
+
+pub trait InternalRow: DataGetters {
+    /// Returns the number of fields in this row
+    fn get_field_count(&self) -> usize;
 
     /// Returns encoded bytes if already encoded
     fn as_encoded_bytes(&self, _write_format: WriteFormat) -> Option<&[u8]> {
         None
     }
+}
+
+/// Read-side accessor for an ARRAY column.
+pub trait InternalArray: DataGetters {
+    /// Number of elements (including nulls).
+    fn size(&self) -> usize;
+}
+
+/// Read-side accessor for a MAP column. Keys and values are parallel
+/// [`InternalArray`]s indexed in lockstep.
+pub trait InternalMap: Send + Sync {
+    /// Number of key/value entries.
+    fn size(&self) -> usize;
+
+    /// Keys in entry order; the binary-map invariant guarantees no nulls.
+    fn key_array(&self) -> &dyn InternalArray;
+
+    /// Values in entry order, paired with [`Self::key_array`] by position.
+    fn value_array(&self) -> &dyn InternalArray;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
@@ -182,7 +176,9 @@ impl<'a> InternalRow for GenericRow<'a> {
     fn get_field_count(&self) -> usize {
         self.values.len()
     }
+}
 
+impl<'a> DataGetters for GenericRow<'a> {
     fn is_null_at(&self, pos: usize) -> Result<bool> {
         Ok(self.get_value(pos)?.is_null())
     }
@@ -299,27 +295,27 @@ impl<'a> InternalRow for GenericRow<'a> {
         }
     }
 
-    fn get_array(&self, pos: usize) -> Result<FlussArray> {
+    fn get_array(&self, pos: usize) -> Result<view::ArrayView<'_>> {
         match self.get_value(pos)? {
-            Datum::Array(a) => Ok(a.clone()),
+            Datum::Array(a) => Ok(view::ArrayView::Binary(a.clone())),
             other => Err(IllegalArgument {
                 message: format!("type mismatch at position {pos}: expected Array, got {other:?}"),
             }),
         }
     }
 
-    fn get_map(&self, pos: usize) -> Result<FlussMap> {
+    fn get_map(&self, pos: usize) -> Result<view::MapView<'_>> {
         match self.get_value(pos)? {
-            Datum::Map(m) => Ok(m.clone()),
+            Datum::Map(m) => Ok(view::MapView::Binary(m.clone())),
             other => Err(IllegalArgument {
                 message: format!("type mismatch at position {pos}: expected Map, got {other:?}"),
             }),
         }
     }
 
-    fn get_row(&self, pos: usize) -> Result<&GenericRow<'_>> {
+    fn get_row(&self, pos: usize) -> Result<view::RowView<'_>> {
         match self.get_value(pos)? {
-            Datum::Row(r) => Ok(r.as_ref()),
+            Datum::Row(r) => Ok(view::RowView::Generic(r.as_ref())),
             other => Err(IllegalArgument {
                 message: format!("type mismatch at position {pos}: expected Row, got {other:?}"),
             }),

--- a/crates/fluss/src/row/projected_row.rs
+++ b/crates/fluss/src/row/projected_row.rs
@@ -23,7 +23,8 @@ use crate::error::Error::IllegalArgument;
 use crate::error::Result;
 use crate::metadata::UNEXIST_MAPPING;
 use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz};
-use crate::row::{Decimal, FlussArray, FlussMap, GenericRow, InternalRow};
+use crate::row::view::{ArrayView, MapView, RowView};
+use crate::row::{DataGetters, Decimal, InternalRow};
 use std::sync::Arc;
 
 pub(crate) struct ProjectedRow<R> {
@@ -73,6 +74,14 @@ impl<R: InternalRow> InternalRow for ProjectedRow<R> {
         self.index_mapping.len()
     }
 
+    fn as_encoded_bytes(&self, _write_format: WriteFormat) -> Option<&[u8]> {
+        // Projection changes the field layout, so the inner row's
+        // encoded form no longer matches.
+        None
+    }
+}
+
+impl<R: InternalRow> DataGetters for ProjectedRow<R> {
     fn is_null_at(&self, pos: usize) -> Result<bool> {
         let mapped = self
             .index_mapping
@@ -138,22 +147,16 @@ impl<R: InternalRow> InternalRow for ProjectedRow<R> {
     fn get_bytes(&self, pos: usize) -> Result<&[u8]> {
         project!(self, get_bytes, pos)
     }
-    fn get_array(&self, pos: usize) -> Result<FlussArray> {
+    fn get_array(&self, pos: usize) -> Result<ArrayView<'_>> {
         project!(self, get_array, pos)
     }
 
-    fn get_map(&self, pos: usize) -> Result<FlussMap> {
+    fn get_map(&self, pos: usize) -> Result<MapView<'_>> {
         project!(self, get_map, pos)
     }
 
-    fn get_row(&self, pos: usize) -> Result<&GenericRow<'_>> {
+    fn get_row(&self, pos: usize) -> Result<RowView<'_>> {
         project!(self, get_row, pos)
-    }
-
-    fn as_encoded_bytes(&self, _write_format: WriteFormat) -> Option<&[u8]> {
-        // Projection changes the field layout, so the inner row's
-        // encoded form no longer matches.
-        None
     }
 }
 

--- a/crates/fluss/src/row/row_decoder.rs
+++ b/crates/fluss/src/row/row_decoder.rs
@@ -90,9 +90,9 @@ impl RowDecoderFactory {
 mod tests {
     use super::*;
     use crate::metadata::DataTypes;
-    use crate::row::InternalRow;
     use crate::row::binary::BinaryWriter;
     use crate::row::compacted::CompactedRowWriter;
+    use crate::row::{DataGetters, InternalRow};
 
     #[test]
     fn test_compacted_row_decoder() {

--- a/crates/fluss/src/row/view.rs
+++ b/crates/fluss/src/row/view.rs
@@ -54,7 +54,8 @@ impl ArrayView<'_> {
         }
     }
 
-    /// [`try_into_binary`](Self::try_into_binary) with `.expect()`. For tests.
+    /// [`try_into_binary`](Self::try_into_binary) with `.expect()`. Test-only.
+    #[cfg(any(test, feature = "integration_tests"))]
     pub fn expect_binary(self) -> FlussArray {
         self.try_into_binary()
             .expect("materialize ColumnarArray to FlussArray")
@@ -149,7 +150,8 @@ impl MapView<'_> {
         }
     }
 
-    /// [`try_into_binary`](Self::try_into_binary) with `.expect()`. For tests.
+    /// [`try_into_binary`](Self::try_into_binary) with `.expect()`. Test-only.
+    #[cfg(any(test, feature = "integration_tests"))]
     pub fn expect_binary(self) -> FlussMap {
         self.try_into_binary()
             .expect("materialize ColumnarMap to FlussMap")

--- a/crates/fluss/src/row/view.rs
+++ b/crates/fluss/src/row/view.rs
@@ -1,0 +1,670 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! View enums bridging binary and columnar `ARRAY` / `MAP` / `ROW`. Callers
+//! dispatch through [`InternalArray`] / [`InternalMap`] / [`InternalRow`] and
+//! pattern-match only when they need to distinguish the representation.
+
+use crate::client::WriteFormat;
+use crate::error::Error::IllegalArgument;
+use crate::error::Result;
+use crate::metadata::{DataField, DataType, DataTypes, RowType};
+use crate::row::Decimal;
+use crate::row::binary_array::{FlussArray, FlussArrayWriter};
+use crate::row::binary_map::FlussMap;
+use crate::row::column::ColumnarRow;
+use crate::row::column_vector::{TimeColumn, TimestampColumn, TypedColumn};
+use crate::row::columnar::{ColumnarArray, ColumnarMap};
+use crate::row::datum::{Date, Time, TimestampLtz, TimestampNtz, internal_row_to_owned_generic};
+use crate::row::{DataGetters, GenericRow, InternalArray, InternalMap, InternalRow};
+use arrow::array::Array;
+use arrow::datatypes::DataType as ArrowDataType;
+
+/// Either an owned binary [`FlussArray`] or a borrowed columnar slice view
+/// over an Arrow buffer. The `'a` lifetime is used only by the columnar
+/// variant; binary values are self-owned (`FlussArray`'s `Bytes` is
+/// reference-counted, so cloning is O(1)).
+#[derive(Debug, Clone)]
+pub enum ArrayView<'a> {
+    Binary(FlussArray),
+    Columnar(ColumnarArray<'a>),
+}
+
+impl ArrayView<'_> {
+    /// Returns the owned binary [`FlussArray`] form, re-encoding a columnar
+    /// slice if needed. Prefer the trait accessors for zero-copy reads.
+    pub fn try_into_binary(self) -> Result<FlussArray> {
+        match self {
+            Self::Binary(a) => Ok(a),
+            Self::Columnar(c) => materialize_columnar_array(&c),
+        }
+    }
+
+    /// [`try_into_binary`](Self::try_into_binary) with `.expect()`. For tests.
+    pub fn expect_binary(self) -> FlussArray {
+        self.try_into_binary()
+            .expect("materialize ColumnarArray to FlussArray")
+    }
+}
+
+impl InternalArray for ArrayView<'_> {
+    fn size(&self) -> usize {
+        delegate_array_view!(InternalArray, self.size())
+    }
+}
+
+impl DataGetters for ArrayView<'_> {
+    fn is_null_at(&self, pos: usize) -> Result<bool> {
+        delegate_array_view!(DataGetters, self.is_null_at(pos))
+    }
+
+    fn get_boolean(&self, pos: usize) -> Result<bool> {
+        delegate_array_view!(DataGetters, self.get_boolean(pos))
+    }
+    fn get_byte(&self, pos: usize) -> Result<i8> {
+        delegate_array_view!(DataGetters, self.get_byte(pos))
+    }
+    fn get_short(&self, pos: usize) -> Result<i16> {
+        delegate_array_view!(DataGetters, self.get_short(pos))
+    }
+    fn get_int(&self, pos: usize) -> Result<i32> {
+        delegate_array_view!(DataGetters, self.get_int(pos))
+    }
+    fn get_long(&self, pos: usize) -> Result<i64> {
+        delegate_array_view!(DataGetters, self.get_long(pos))
+    }
+    fn get_float(&self, pos: usize) -> Result<f32> {
+        delegate_array_view!(DataGetters, self.get_float(pos))
+    }
+    fn get_double(&self, pos: usize) -> Result<f64> {
+        delegate_array_view!(DataGetters, self.get_double(pos))
+    }
+    fn get_char(&self, pos: usize, length: usize) -> Result<&str> {
+        delegate_array_view!(DataGetters, self.get_char(pos, length))
+    }
+    fn get_string(&self, pos: usize) -> Result<&str> {
+        delegate_array_view!(DataGetters, self.get_string(pos))
+    }
+    fn get_decimal(&self, pos: usize, precision: usize, scale: usize) -> Result<Decimal> {
+        delegate_array_view!(DataGetters, self.get_decimal(pos, precision, scale))
+    }
+    fn get_date(&self, pos: usize) -> Result<Date> {
+        delegate_array_view!(DataGetters, self.get_date(pos))
+    }
+    fn get_time(&self, pos: usize) -> Result<Time> {
+        delegate_array_view!(DataGetters, self.get_time(pos))
+    }
+    fn get_timestamp_ntz(&self, pos: usize, precision: u32) -> Result<TimestampNtz> {
+        delegate_array_view!(DataGetters, self.get_timestamp_ntz(pos, precision))
+    }
+    fn get_timestamp_ltz(&self, pos: usize, precision: u32) -> Result<TimestampLtz> {
+        delegate_array_view!(DataGetters, self.get_timestamp_ltz(pos, precision))
+    }
+    fn get_binary(&self, pos: usize, length: usize) -> Result<&[u8]> {
+        delegate_array_view!(DataGetters, self.get_binary(pos, length))
+    }
+    fn get_bytes(&self, pos: usize) -> Result<&[u8]> {
+        delegate_array_view!(DataGetters, self.get_bytes(pos))
+    }
+
+    fn get_array(&self, pos: usize) -> Result<ArrayView<'_>> {
+        delegate_array_view!(DataGetters, self.get_array(pos))
+    }
+    fn get_map(&self, pos: usize) -> Result<MapView<'_>> {
+        delegate_array_view!(DataGetters, self.get_map(pos))
+    }
+    fn get_row(&self, pos: usize) -> Result<RowView<'_>> {
+        delegate_array_view!(DataGetters, self.get_row(pos))
+    }
+}
+
+/// Either an owned binary [`FlussMap`] or a borrowed columnar slice view.
+#[derive(Debug, Clone)]
+pub enum MapView<'a> {
+    Binary(FlussMap),
+    Columnar(ColumnarMap<'a>),
+}
+
+impl MapView<'_> {
+    /// Returns the owned binary [`FlussMap`] form, re-encoding if needed.
+    /// See [`ArrayView::try_into_binary`].
+    pub fn try_into_binary(self) -> Result<FlussMap> {
+        match self {
+            Self::Binary(m) => Ok(m),
+            Self::Columnar(c) => materialize_columnar_map(&c),
+        }
+    }
+
+    /// [`try_into_binary`](Self::try_into_binary) with `.expect()`. For tests.
+    pub fn expect_binary(self) -> FlussMap {
+        self.try_into_binary()
+            .expect("materialize ColumnarMap to FlussMap")
+    }
+}
+
+impl InternalMap for MapView<'_> {
+    fn size(&self) -> usize {
+        match self {
+            Self::Binary(m) => InternalMap::size(m),
+            Self::Columnar(m) => InternalMap::size(m),
+        }
+    }
+
+    fn key_array(&self) -> &dyn InternalArray {
+        match self {
+            Self::Binary(m) => m.key_array(),
+            Self::Columnar(m) => m.key_array(),
+        }
+    }
+
+    fn value_array(&self) -> &dyn InternalArray {
+        match self {
+            Self::Binary(m) => m.value_array(),
+            Self::Columnar(m) => m.value_array(),
+        }
+    }
+}
+
+/// Reconstructs a Fluss `DataType` from a `TypedColumn`. ROW field names
+/// come from the underlying Arrow `StructArray`'s schema.
+fn fluss_type_of(col: &TypedColumn) -> Result<DataType> {
+    Ok(match col {
+        TypedColumn::Boolean(_) => DataTypes::boolean(),
+        TypedColumn::TinyInt(_) => DataTypes::tinyint(),
+        TypedColumn::SmallInt(_) => DataTypes::smallint(),
+        TypedColumn::Int(_) => DataTypes::int(),
+        TypedColumn::BigInt(_) => DataTypes::bigint(),
+        TypedColumn::Float(_) => DataTypes::float(),
+        TypedColumn::Double(_) => DataTypes::double(),
+        TypedColumn::String(_) => DataTypes::string(),
+        TypedColumn::Bytes(_) => DataTypes::bytes(),
+        TypedColumn::Binary(a) => DataTypes::binary(a.value_length() as usize),
+        TypedColumn::Decimal(a, _) => {
+            let (p, s) = match a.data_type() {
+                ArrowDataType::Decimal128(p, s) => (*p, *s),
+                other => {
+                    return Err(IllegalArgument {
+                        message: format!("Decimal128Array expected, got {other:?}"),
+                    });
+                }
+            };
+            DataTypes::decimal(p as u32, s as u32)
+        }
+        TypedColumn::Date(_) => DataTypes::date(),
+        TypedColumn::Time(t) => DataTypes::time_with_precision(time_precision(t)),
+        TypedColumn::Timestamp(t) => DataTypes::timestamp_with_precision(timestamp_precision(t)),
+        TypedColumn::TimestampLtz(t) => {
+            DataTypes::timestamp_ltz_with_precision(timestamp_precision(t))
+        }
+        TypedColumn::Array(_, inner) => DataTypes::array(fluss_type_of(inner)?),
+        TypedColumn::Map(_, k, v) => DataTypes::map(fluss_type_of(k)?, fluss_type_of(v)?),
+        TypedColumn::Row(struct_arr, inner_batch) => {
+            let arrow_fields = match struct_arr.data_type() {
+                ArrowDataType::Struct(f) => f,
+                other => {
+                    return Err(IllegalArgument {
+                        message: format!("Struct expected for ROW column, got {other:?}"),
+                    });
+                }
+            };
+            let mut fields = Vec::with_capacity(inner_batch.columns.len());
+            for (i, col) in inner_batch.columns.iter().enumerate() {
+                let name = arrow_fields.get(i).map(|f| f.name().as_str()).unwrap_or("");
+                fields.push(DataField::new(name.to_string(), fluss_type_of(col)?, None));
+            }
+            DataTypes::row(fields)
+        }
+    })
+}
+
+fn time_precision(t: &TimeColumn) -> u32 {
+    match t {
+        TimeColumn::Second(_) => 0,
+        TimeColumn::Millisecond(_) => 3,
+        TimeColumn::Microsecond(_) => 6,
+        TimeColumn::Nanosecond(_) => 9,
+    }
+}
+
+fn timestamp_precision(t: &TimestampColumn) -> u32 {
+    match t {
+        TimestampColumn::Second(_) => 0,
+        TimestampColumn::Millisecond(_) => 3,
+        TimestampColumn::Microsecond(_) => 6,
+        TimestampColumn::Nanosecond(_) => 9,
+    }
+}
+
+fn materialize_columnar_array(view: &ColumnarArray<'_>) -> Result<FlussArray> {
+    let elem_type = fluss_type_of(view.element())?;
+    let mut writer = FlussArrayWriter::new(view.size(), &elem_type);
+    write_view_elements_into(view, &elem_type, &mut writer)?;
+    writer.complete()
+}
+
+fn materialize_columnar_map(view: &ColumnarMap<'_>) -> Result<FlussMap> {
+    // Map keys are non-nullable by the Fluss spec (mirrors `MapType::with_nullable`).
+    let key_type = fluss_type_of(view.keys_slice().element())?.as_non_nullable();
+    let value_type = fluss_type_of(view.values_slice().element())?;
+    let key_array = materialize_columnar_array(view.keys_slice())?;
+    let value_array = materialize_columnar_array(view.values_slice())?;
+    FlussMap::from_arrays(&key_array, &value_array, &key_type, &value_type)
+}
+
+fn write_view_elements_into(
+    view: &ColumnarArray<'_>,
+    dt: &DataType,
+    writer: &mut FlussArrayWriter,
+) -> Result<()> {
+    for i in 0..view.size() {
+        if view.is_null_at(i)? {
+            writer.set_null_at(i);
+            continue;
+        }
+        match dt {
+            DataType::Boolean(_) => writer.write_boolean(i, view.get_boolean(i)?),
+            DataType::TinyInt(_) => writer.write_byte(i, view.get_byte(i)?),
+            DataType::SmallInt(_) => writer.write_short(i, view.get_short(i)?),
+            DataType::Int(_) => writer.write_int(i, view.get_int(i)?),
+            DataType::BigInt(_) => writer.write_long(i, view.get_long(i)?),
+            DataType::Float(_) => writer.write_float(i, view.get_float(i)?),
+            DataType::Double(_) => writer.write_double(i, view.get_double(i)?),
+            DataType::Char(_) | DataType::String(_) => {
+                writer.write_string(i, view.get_string(i)?);
+            }
+            DataType::Binary(t) => {
+                writer.write_binary_bytes(i, view.get_binary(i, t.length())?);
+            }
+            DataType::Bytes(_) => writer.write_binary_bytes(i, view.get_bytes(i)?),
+            DataType::Decimal(d) => {
+                let dec = view.get_decimal(i, d.precision() as usize, d.scale() as usize)?;
+                writer.write_decimal(i, &dec, d.precision());
+            }
+            DataType::Date(_) => writer.write_date(i, view.get_date(i)?),
+            DataType::Time(_) => writer.write_time(i, view.get_time(i)?),
+            DataType::Timestamp(t) => {
+                let ts = view.get_timestamp_ntz(i, t.precision())?;
+                writer.write_timestamp_ntz(i, &ts, t.precision());
+            }
+            DataType::TimestampLTz(t) => {
+                let ts = view.get_timestamp_ltz(i, t.precision())?;
+                writer.write_timestamp_ltz(i, &ts, t.precision());
+            }
+            DataType::Array(_) => {
+                let nested = view.get_array(i)?.try_into_binary()?;
+                writer.write_array(i, &nested);
+            }
+            DataType::Map(_) => {
+                let nested = view.get_map(i)?.try_into_binary()?;
+                writer.write_map(i, &nested);
+            }
+            DataType::Row(_) => match view.get_row(i)? {
+                RowView::Columnar(cr) => writer.write_row(i, &cr)?,
+                RowView::Generic(g) => writer.write_row(i, g)?,
+            },
+        }
+    }
+    Ok(())
+}
+
+/// Delegates an [`ArrayView`] method to whichever variant is present, going
+/// through the trait so the call binds to the [`InternalArray`] impl rather
+/// than any inherent method of the same name (which may have different
+/// argument types — e.g. `FlussArray::get_decimal` takes `u32`s).
+macro_rules! delegate_array_view {
+    ($trait:ident, $self:ident . $method:ident ( $($arg:expr),* )) => {
+        match $self {
+            Self::Binary(x) => $trait::$method(x, $($arg),*),
+            Self::Columnar(x) => $trait::$method(x, $($arg),*),
+        }
+    };
+}
+use delegate_array_view;
+
+/// Either a borrowed reference to a materialized [`GenericRow`] (binary /
+/// compacted paths) or an owned [`ColumnarRow`] cursor (Arrow scan path).
+#[derive(Debug)]
+pub enum RowView<'a> {
+    Generic(&'a GenericRow<'a>),
+    Columnar(ColumnarRow),
+}
+
+impl RowView<'_> {
+    /// Materializes into an owned [`GenericRow`], walking a columnar cursor
+    /// field-by-field if needed. Read-only consumers should iterate the
+    /// [`InternalRow`] trait directly.
+    pub fn try_into_generic(self, row_type: &RowType) -> Result<GenericRow<'static>> {
+        match self {
+            Self::Generic(g) => Ok(g.clone().into_owned()),
+            Self::Columnar(cr) => internal_row_to_owned_generic(&cr, row_type),
+        }
+    }
+}
+
+/// Delegates a [`RowView`] method through the [`InternalRow`] trait. Method
+/// syntax handles the `&&GenericRow → &GenericRow` auto-deref on the
+/// Generic variant.
+macro_rules! delegate_row_view {
+    ($trait:ident, $self:ident . $method:ident ( $($arg:expr),* )) => {
+        match $self {
+            Self::Generic(x) => $trait::$method(*x, $($arg),*),
+            Self::Columnar(x) => $trait::$method(x, $($arg),*),
+        }
+    };
+}
+
+impl InternalRow for RowView<'_> {
+    fn get_field_count(&self) -> usize {
+        delegate_row_view!(InternalRow, self.get_field_count())
+    }
+
+    fn as_encoded_bytes(&self, write_format: WriteFormat) -> Option<&[u8]> {
+        delegate_row_view!(InternalRow, self.as_encoded_bytes(write_format))
+    }
+}
+
+impl DataGetters for RowView<'_> {
+    fn is_null_at(&self, pos: usize) -> Result<bool> {
+        delegate_row_view!(DataGetters, self.is_null_at(pos))
+    }
+
+    fn get_boolean(&self, pos: usize) -> Result<bool> {
+        delegate_row_view!(DataGetters, self.get_boolean(pos))
+    }
+    fn get_byte(&self, pos: usize) -> Result<i8> {
+        delegate_row_view!(DataGetters, self.get_byte(pos))
+    }
+    fn get_short(&self, pos: usize) -> Result<i16> {
+        delegate_row_view!(DataGetters, self.get_short(pos))
+    }
+    fn get_int(&self, pos: usize) -> Result<i32> {
+        delegate_row_view!(DataGetters, self.get_int(pos))
+    }
+    fn get_long(&self, pos: usize) -> Result<i64> {
+        delegate_row_view!(DataGetters, self.get_long(pos))
+    }
+    fn get_float(&self, pos: usize) -> Result<f32> {
+        delegate_row_view!(DataGetters, self.get_float(pos))
+    }
+    fn get_double(&self, pos: usize) -> Result<f64> {
+        delegate_row_view!(DataGetters, self.get_double(pos))
+    }
+
+    fn get_char(&self, pos: usize, length: usize) -> Result<&str> {
+        delegate_row_view!(DataGetters, self.get_char(pos, length))
+    }
+    fn get_string(&self, pos: usize) -> Result<&str> {
+        delegate_row_view!(DataGetters, self.get_string(pos))
+    }
+
+    fn get_decimal(&self, pos: usize, precision: usize, scale: usize) -> Result<Decimal> {
+        delegate_row_view!(DataGetters, self.get_decimal(pos, precision, scale))
+    }
+
+    fn get_date(&self, pos: usize) -> Result<Date> {
+        delegate_row_view!(DataGetters, self.get_date(pos))
+    }
+    fn get_time(&self, pos: usize) -> Result<Time> {
+        delegate_row_view!(DataGetters, self.get_time(pos))
+    }
+    fn get_timestamp_ntz(&self, pos: usize, precision: u32) -> Result<TimestampNtz> {
+        delegate_row_view!(DataGetters, self.get_timestamp_ntz(pos, precision))
+    }
+    fn get_timestamp_ltz(&self, pos: usize, precision: u32) -> Result<TimestampLtz> {
+        delegate_row_view!(DataGetters, self.get_timestamp_ltz(pos, precision))
+    }
+
+    fn get_binary(&self, pos: usize, length: usize) -> Result<&[u8]> {
+        delegate_row_view!(DataGetters, self.get_binary(pos, length))
+    }
+    fn get_bytes(&self, pos: usize) -> Result<&[u8]> {
+        delegate_row_view!(DataGetters, self.get_bytes(pos))
+    }
+
+    fn get_array(&self, pos: usize) -> Result<ArrayView<'_>> {
+        delegate_row_view!(DataGetters, self.get_array(pos))
+    }
+    fn get_map(&self, pos: usize) -> Result<MapView<'_>> {
+        delegate_row_view!(DataGetters, self.get_map(pos))
+    }
+    fn get_row(&self, pos: usize) -> Result<RowView<'_>> {
+        delegate_row_view!(DataGetters, self.get_row(pos))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::{DataTypes, RowType};
+    use crate::row::binary_array::FlussArrayWriter;
+    use crate::row::binary_map::FlussMapWriter;
+    use crate::row::column::ColumnarRow;
+    use crate::row::column_vector::{TypedBatch, TypedColumn};
+    use crate::row::field_getter::FieldGetter;
+    use crate::row::{DataGetters, Datum};
+    use arrow::array::{
+        Array, ArrayRef, Int32Array, ListArray, MapArray, RecordBatch, StringArray, StructArray,
+    };
+    use arrow::buffer::OffsetBuffer;
+    use arrow::datatypes::{DataType as ArrowDataType, Field, Fields, Schema};
+    use std::sync::Arc;
+
+    #[test]
+    fn binary_array_view_delegates_to_fluss_array() {
+        let mut w = FlussArrayWriter::new(2, &DataTypes::int());
+        w.write_int(0, 7);
+        w.write_int(1, 8);
+        let arr = w.complete().unwrap();
+        let view = ArrayView::Binary(arr);
+
+        let dispatched: &dyn InternalArray = &view;
+        assert_eq!(dispatched.size(), 2);
+        assert_eq!(dispatched.get_int(0).unwrap(), 7);
+        assert_eq!(dispatched.get_int(1).unwrap(), 8);
+    }
+
+    #[test]
+    fn columnar_array_view_delegates_to_slice() {
+        let values = Int32Array::from(vec![10, 20, 30, 40, 50]);
+        let offsets = OffsetBuffer::new(vec![0_i32, 2, 5].into());
+        let list = ListArray::new(
+            Arc::new(Field::new("item", ArrowDataType::Int32, true)),
+            offsets,
+            Arc::new(values),
+            None,
+        );
+        let rb = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "arr",
+                list.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(list.clone()) as ArrayRef],
+        )
+        .unwrap();
+        let rt = RowType::new(vec![DataField::new(
+            "arr",
+            DataTypes::array(DataTypes::int()),
+            None,
+        )]);
+        let tb = TypedBatch::build(&rb, &rt).unwrap();
+        let element = match &tb.columns[0] {
+            TypedColumn::Array(_, e) => e.as_ref(),
+            _ => unreachable!(),
+        };
+        // Second row's slice — [30, 40, 50].
+        let view = ArrayView::Columnar(ColumnarArray::new(element, 2, 3));
+
+        let dispatched: &dyn InternalArray = &view;
+        assert_eq!(dispatched.size(), 3);
+        assert_eq!(dispatched.get_int(0).unwrap(), 30);
+        assert_eq!(dispatched.get_int(2).unwrap(), 50);
+    }
+
+    #[test]
+    fn binary_map_view_delegates_to_fluss_map() {
+        let mut w = FlussMapWriter::new(2, &DataTypes::int(), &DataTypes::string());
+        w.write_entry(1.into(), "a".into()).unwrap();
+        w.write_entry(2.into(), "b".into()).unwrap();
+        let map = w.complete().unwrap();
+        let view = MapView::Binary(map);
+
+        let dispatched: &dyn InternalMap = &view;
+        assert_eq!(dispatched.size(), 2);
+        assert_eq!(dispatched.key_array().get_int(0).unwrap(), 1);
+        assert_eq!(dispatched.value_array().get_string(0).unwrap(), "a");
+    }
+
+    #[test]
+    fn columnar_map_view_delegates_to_slice() {
+        let keys = StringArray::from(vec!["x", "y"]);
+        let values = Int32Array::from(vec![100, 200]);
+        let entries_fields = Fields::from(vec![
+            Field::new("keys", ArrowDataType::Utf8, false),
+            Field::new("values", ArrowDataType::Int32, true),
+        ]);
+        let entries = StructArray::new(
+            entries_fields.clone(),
+            vec![Arc::new(keys) as ArrayRef, Arc::new(values) as ArrayRef],
+            None,
+        );
+        let offsets = OffsetBuffer::new(vec![0_i32, 2].into());
+        let map = MapArray::new(
+            Arc::new(Field::new(
+                "entries",
+                ArrowDataType::Struct(entries_fields),
+                false,
+            )),
+            offsets,
+            entries,
+            None,
+            false,
+        );
+        let rb = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "m",
+                map.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(map.clone()) as ArrayRef],
+        )
+        .unwrap();
+        let rt = RowType::new(vec![DataField::new(
+            "m",
+            DataTypes::map(DataTypes::string(), DataTypes::int()),
+            None,
+        )]);
+        let tb = TypedBatch::build(&rb, &rt).unwrap();
+        let (key_col, value_col) = match &tb.columns[0] {
+            TypedColumn::Map(_, k, v) => (k.as_ref(), v.as_ref()),
+            _ => unreachable!(),
+        };
+        let view = MapView::Columnar(ColumnarMap::new(key_col, value_col, 0, 2));
+
+        let dispatched: &dyn InternalMap = &view;
+        assert_eq!(dispatched.size(), 2);
+        assert_eq!(dispatched.key_array().get_string(0).unwrap(), "x");
+        assert_eq!(dispatched.value_array().get_int(1).unwrap(), 200);
+    }
+
+    #[test]
+    fn array_of_row_with_nested_array_materializes_end_to_end() {
+        // [ { x: 1, y: [10, 20] }, { x: 2, y: [30] } ]
+        let inner_x = Int32Array::from(vec![1, 2]);
+        let inner_y_values = Int32Array::from(vec![10, 20, 30]);
+        let inner_y_offsets = OffsetBuffer::new(vec![0_i32, 2, 3].into());
+        let inner_y_list = ListArray::new(
+            Arc::new(Field::new("item", ArrowDataType::Int32, true)),
+            inner_y_offsets,
+            Arc::new(inner_y_values),
+            None,
+        );
+        let row_fields = Fields::from(vec![
+            Field::new("x", ArrowDataType::Int32, true),
+            Field::new(
+                "y",
+                ArrowDataType::List(Arc::new(Field::new("item", ArrowDataType::Int32, true))),
+                true,
+            ),
+        ]);
+        let struct_arr = StructArray::new(
+            row_fields.clone(),
+            vec![
+                Arc::new(inner_x) as ArrayRef,
+                Arc::new(inner_y_list) as ArrayRef,
+            ],
+            None,
+        );
+        let outer_offsets = OffsetBuffer::new(vec![0_i32, 2].into());
+        let outer_list = ListArray::new(
+            Arc::new(Field::new("item", ArrowDataType::Struct(row_fields), true)),
+            outer_offsets,
+            Arc::new(struct_arr),
+            None,
+        );
+        let rb = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "arr",
+                outer_list.data_type().clone(),
+                true,
+            )])),
+            vec![Arc::new(outer_list) as ArrayRef],
+        )
+        .unwrap();
+
+        let inner_row_type = DataTypes::row(vec![
+            DataField::new("x", DataTypes::int(), None),
+            DataField::new("y", DataTypes::array(DataTypes::int()), None),
+        ]);
+        let outer_row_type = Arc::new(RowType::with_data_types(vec![DataTypes::array(
+            inner_row_type,
+        )]));
+        let row = ColumnarRow::new(Arc::new(rb), outer_row_type.clone(), 0, None).unwrap();
+
+        let outer = row.get_array(0).unwrap().try_into_binary().unwrap();
+        assert_eq!(outer.size(), 2);
+
+        let inner_row_dt = DataTypes::row(vec![
+            DataField::new("x", DataTypes::int(), None),
+            DataField::new("y", DataTypes::array(DataTypes::int()), None),
+        ]);
+        let inner_row_type_unwrap = match &inner_row_dt {
+            DataType::Row(rt) => rt.clone(),
+            _ => unreachable!(),
+        };
+        let r0 = outer.get_row(0, &inner_row_type_unwrap).unwrap();
+        assert_eq!(r0.get_int(0).unwrap(), 1);
+        let r0_y = r0.get_array(1).unwrap().try_into_binary().unwrap();
+        assert_eq!(r0_y.size(), 2);
+        assert_eq!(r0_y.get_int(0).unwrap(), 10);
+        assert_eq!(r0_y.get_int(1).unwrap(), 20);
+
+        let r1 = outer.get_row(1, &inner_row_type_unwrap).unwrap();
+        assert_eq!(r1.get_int(0).unwrap(), 2);
+        let r1_y = r1.get_array(1).unwrap().try_into_binary().unwrap();
+        assert_eq!(r1_y.size(), 1);
+        assert_eq!(r1_y.get_int(0).unwrap(), 30);
+
+        // FieldGetter is the surface every binding's row→Datum converter hits.
+        let getter = FieldGetter::create(&DataTypes::array(inner_row_dt), 0);
+        let datum = getter.get_field(&row).unwrap();
+        match datum {
+            Datum::Array(a) => assert_eq!(a.size(), 2),
+            other => panic!("expected Datum::Array, got {other:?}"),
+        }
+    }
+}

--- a/crates/fluss/tests/integration/kv_table.rs
+++ b/crates/fluss/tests/integration/kv_table.rs
@@ -28,7 +28,8 @@ mod kv_table_test {
     use fluss::row::binary_array::FlussArrayWriter;
     use fluss::row::binary_map::FlussMapWriter;
     use fluss::row::{
-        Date, Datum, Decimal, GenericRow, InternalRow, Time, TimestampLtz, TimestampNtz,
+        DataGetters, Date, Datum, Decimal, GenericRow, InternalArray, InternalMap, Time,
+        TimestampLtz, TimestampNtz,
     };
     use futures::stream::{FuturesUnordered, StreamExt};
 
@@ -441,7 +442,7 @@ mod kv_table_test {
         assert_eq!(r.get_string(1).unwrap(), "Verso", "name preserved");
         let n = r.get_row(3).unwrap();
         assert_eq!(n.get_int(0).unwrap(), 99, "ROW preserved");
-        let m = r.get_map(4).unwrap();
+        let m = r.get_map(4).unwrap().expect_binary();
         assert_eq!(m.size(), 1);
         assert_eq!(m.get(&Datum::from("z")).unwrap(), Some(Datum::from(99_i32)));
         assert_eq!(r.get_array(5).unwrap().size(), 2, "ARRAY preserved");
@@ -571,7 +572,7 @@ mod kv_table_test {
             let nested = row.get_row(4).unwrap();
             assert_eq!(nested.get_int(0).unwrap(), *seq);
             assert_eq!(nested.get_string(1).unwrap(), *label);
-            let attrs = row.get_map(5).unwrap();
+            let attrs = row.get_map(5).unwrap().expect_binary();
             assert_eq!(attrs.size(), 1);
             assert_eq!(
                 attrs.get(&Datum::from(*label)).unwrap(),
@@ -618,7 +619,7 @@ mod kv_table_test {
         assert_eq!(row.get_long(3).unwrap(), 999);
         let nested = row.get_row(4).unwrap();
         assert_eq!(nested.get_int(0).unwrap(), 999);
-        let attrs = row.get_map(5).unwrap();
+        let attrs = row.get_map(5).unwrap().expect_binary();
         assert_eq!(
             attrs.get(&Datum::from("u")).unwrap(),
             Some(Datum::from(999_i32))
@@ -1535,7 +1536,7 @@ mod kv_table_test {
         assert_eq!(arr_of_arr.get_array(1).unwrap().get_int(1).unwrap(), 4);
 
         // === ARRAY<ROW> ===
-        let aor = r1.get_array(4).unwrap();
+        let aor = r1.get_array(4).unwrap().expect_binary();
         assert_eq!(aor.size(), 2);
         let e0 = aor.get_row(0, &row_seq_label).unwrap();
         assert_eq!(e0.get_int(0).unwrap(), 1);
@@ -1573,23 +1574,23 @@ mod kv_table_test {
         assert_eq!(rr.get_binary(12, 4).unwrap(), b"\x01\x02\x03\x04");
         let f_arr = rr.get_array(13).unwrap();
         assert_eq!(f_arr.size(), 3);
-        assert!(f_arr.is_null_at(1));
+        assert!(f_arr.is_null_at(1).unwrap());
 
         // === MAP: basic ===
-        let m = r1.get_map(8).unwrap();
+        let m = r1.get_map(8).unwrap().expect_binary();
         assert_eq!(m.size(), 3);
         assert_eq!(m.get(&Datum::from("a")).unwrap(), Some(Datum::from(1_i32)));
         assert_eq!(m.get(&Datum::from("b")).unwrap(), Some(Datum::Null));
         assert_eq!(m.get(&Datum::from("c")).unwrap(), Some(Datum::from(3_i32)));
 
         // === MAP<K, ROW> ===
-        let m = r1.get_map(9).unwrap();
+        let m = r1.get_map(9).unwrap().expect_binary();
         let v0 = m.value_array().get_row(0, &row_seq_label).unwrap();
         assert_eq!(v0.get_int(0).unwrap(), 1);
         assert_eq!(v0.get_string(1).unwrap(), "open");
 
         // === MAP<K, MAP> ===
-        let m = r1.get_map(10).unwrap();
+        let m = r1.get_map(10).unwrap().expect_binary();
         let g1 = m
             .value_array()
             .get_map(0, &DataTypes::string(), &DataTypes::int())
@@ -1597,9 +1598,9 @@ mod kv_table_test {
         assert_eq!(g1.size(), 2);
 
         // === MAP<K, ARRAY> + ARRAY<MAP> ===
-        let m = r1.get_map(11).unwrap();
+        let m = r1.get_map(11).unwrap().expect_binary();
         assert_eq!(m.value_array().get_array(0).unwrap().size(), 3);
-        let am = r1.get_array(12).unwrap();
+        let am = r1.get_array(12).unwrap().expect_binary();
         assert_eq!(am.size(), 2);
         let am0 = am
             .get_map(0, &DataTypes::string(), &DataTypes::int())

--- a/crates/fluss/tests/integration/log_table.rs
+++ b/crates/fluss/tests/integration/log_table.rs
@@ -31,7 +31,8 @@ mod table_test {
     use fluss::row::binary_array::FlussArrayWriter;
     use fluss::row::binary_map::FlussMapWriter;
     use fluss::row::{
-        Date, Datum, Decimal, FlussArray, GenericRow, InternalRow, Time, TimestampLtz, TimestampNtz,
+        DataGetters, Date, Datum, Decimal, GenericRow, InternalArray, InternalMap, Time,
+        TimestampLtz, TimestampNtz,
     };
     use fluss::rpc::message::OffsetSpec;
     use std::collections::HashMap;
@@ -937,7 +938,10 @@ mod table_test {
         assert_eq!(projected_nested.get_string(1).unwrap(), "hello");
 
         // === Projection: MAP ===
-        let m = r.get_map(1).expect("get_map over projection");
+        let m = r
+            .get_map(1)
+            .expect("get_map over projection")
+            .expect_binary();
         assert_eq!(m.size(), 2);
         assert_eq!(m.get(&Datum::from("x")).unwrap(), Some(Datum::from(1_i32)));
         assert_eq!(m.get(&Datum::from("y")).unwrap(), Some(Datum::from(2_i32)));
@@ -1543,13 +1547,13 @@ mod table_test {
         assert_eq!(r1.get_array(1).unwrap().size(), 0);
         let arr_string_r1 = r1.get_array(2).unwrap();
         assert_eq!(arr_string_r1.size(), 1);
-        assert!(arr_string_r1.is_null_at(0));
+        assert!(arr_string_r1.is_null_at(0).unwrap());
         let arr_of_arr_r1 = r1.get_array(3).unwrap();
         assert_eq!(arr_of_arr_r1.size(), 3);
         let aa0 = arr_of_arr_r1.get_array(0).unwrap();
         assert_eq!(aa0.size(), 1);
         assert_eq!(aa0.get_int(0).unwrap(), 5);
-        assert!(arr_of_arr_r1.is_null_at(1));
+        assert!(arr_of_arr_r1.is_null_at(1).unwrap());
         assert_eq!(arr_of_arr_r1.get_array(2).unwrap().size(), 0);
 
         // === ARRAY: null whole column on row 2 ===
@@ -1558,7 +1562,7 @@ mod table_test {
         assert!(r2.is_null_at(3).unwrap());
 
         // === ARRAY<ROW>: row 0 + row 1 with null element + row 2 null whole ===
-        let aor0 = r0.get_array(4).unwrap();
+        let aor0 = r0.get_array(4).unwrap().expect_binary();
         assert_eq!(aor0.size(), 2);
         let e0 = aor0.get_row(0, &row_seq_label).unwrap();
         assert_eq!(e0.get_int(0).unwrap(), 1);
@@ -1566,7 +1570,7 @@ mod table_test {
         let e1 = aor0.get_row(1, &row_seq_label).unwrap();
         assert_eq!(e1.get_int(0).unwrap(), 2);
         assert_eq!(e1.get_string(1).unwrap(), "close");
-        let aor1 = r1.get_array(4).unwrap();
+        let aor1 = r1.get_array(4).unwrap().expect_binary();
         assert_eq!(aor1.size(), 3);
         let e0 = aor1.get_row(0, &row_seq_label).unwrap();
         assert_eq!(e0.get_int(0).unwrap(), 7);
@@ -1605,13 +1609,13 @@ mod table_test {
         let f_arr = rr.get_array(13).unwrap();
         assert_eq!(f_arr.size(), 3);
         assert_eq!(f_arr.get_int(0).unwrap(), 7);
-        assert!(f_arr.is_null_at(1));
+        assert!(f_arr.is_null_at(1).unwrap());
         assert!(r2.is_null_at(5).unwrap());
         assert!(r2.is_null_at(6).unwrap());
         assert!(r2.is_null_at(7).unwrap());
 
         // === MAP: basic (with null value) + empty (row 1) + null (row 2) ===
-        let m = r0.get_map(8).unwrap();
+        let m = r0.get_map(8).unwrap().expect_binary();
         assert_eq!(m.size(), 3);
         assert_eq!(m.get(&Datum::from("a")).unwrap(), Some(Datum::from(1_i32)));
         assert_eq!(m.get(&Datum::from("b")).unwrap(), Some(Datum::Null));
@@ -1620,7 +1624,7 @@ mod table_test {
         assert!(r2.is_null_at(8).unwrap());
 
         // === MAP<K, ROW> ===
-        let m = r0.get_map(9).unwrap();
+        let m = r0.get_map(9).unwrap().expect_binary();
         assert_eq!(m.size(), 2);
         let keys = m.key_array();
         let values = m.value_array();
@@ -1634,7 +1638,7 @@ mod table_test {
         assert_eq!(v1.get_string(1).unwrap(), "close");
 
         // === MAP<K, MAP> ===
-        let m = r0.get_map(10).unwrap();
+        let m = r0.get_map(10).unwrap().expect_binary();
         assert_eq!(m.size(), 2);
         let g1 = m
             .value_array()
@@ -1650,12 +1654,12 @@ mod table_test {
         assert_eq!(g2.get(&Datum::from("c")).unwrap(), Some(Datum::from(3_i32)));
 
         // === MAP<K, ARRAY> + ARRAY<MAP> ===
-        let m = r0.get_map(11).unwrap();
+        let m = r0.get_map(11).unwrap().expect_binary();
         assert_eq!(m.size(), 2);
         let primes = m.value_array().get_array(0).unwrap();
         assert_eq!(primes.size(), 3);
         assert_eq!(primes.get_int(2).unwrap(), 5);
-        let am = r0.get_array(12).unwrap();
+        let am = r0.get_array(12).unwrap().expect_binary();
         assert_eq!(am.size(), 2);
         let am0 = am
             .get_map(0, &DataTypes::string(), &DataTypes::int())
@@ -1674,13 +1678,13 @@ mod table_test {
         let ab = r0.get_array(13).unwrap();
         assert_eq!(ab.size(), 2);
         assert_eq!(ab.get_bytes(0).unwrap(), bytes_v.as_slice());
-        assert!(ab.is_null_at(1));
+        assert!(ab.is_null_at(1).unwrap());
         let ad = r0.get_array(14).unwrap();
         assert_eq!(ad.get_date(0).unwrap().get_inner(), date_v.get_inner());
-        assert!(ad.is_null_at(1));
+        assert!(ad.is_null_at(1).unwrap());
         let at = r0.get_array(15).unwrap();
         assert_eq!(at.get_time(0).unwrap().get_inner(), time_v.get_inner());
-        assert!(at.is_null_at(1));
+        assert!(at.is_null_at(1).unwrap());
         let ats = r0.get_array(16).unwrap();
         let read_ts = ats.get_timestamp_ntz(0, 6).unwrap();
         assert_eq!(read_ts.get_millisecond(), ts_v.get_millisecond());
@@ -1688,16 +1692,16 @@ mod table_test {
             read_ts.get_nano_of_millisecond(),
             ts_v.get_nano_of_millisecond()
         );
-        assert!(ats.is_null_at(1));
+        assert!(ats.is_null_at(1).unwrap());
         let atl = r0.get_array(17).unwrap();
         assert_eq!(
             atl.get_timestamp_ltz(0, 3).unwrap().get_epoch_millisecond(),
             ts_ltz_v.get_epoch_millisecond()
         );
-        assert!(atl.is_null_at(1));
+        assert!(atl.is_null_at(1).unwrap());
         let adc = r0.get_array(18).unwrap();
         assert_eq!(adc.get_decimal(0, 10, 2).unwrap(), dec);
-        assert!(adc.is_null_at(1));
+        assert!(adc.is_null_at(1).unwrap());
         let adb = r0.get_array(19).unwrap();
         assert_eq!(adb.get_decimal(0, 22, 5).unwrap(), dec_big);
         let af = r0.get_array(20).unwrap();
@@ -1709,7 +1713,7 @@ mod table_test {
         assert_f64_special(adbl.get_double(0).unwrap(), f64::NAN);
         assert_f64_special(adbl.get_double(1).unwrap(), f64::INFINITY);
         assert_f64_special(adbl.get_double(2).unwrap(), f64::NEG_INFINITY);
-        let fb: FlussArray = r0.get_array(22).unwrap();
+        let fb = r0.get_array(22).unwrap().expect_binary();
         assert_eq!(fb.get_binary(0).unwrap(), fixed_a.as_slice());
         assert_eq!(fb.get_binary(1).unwrap(), fixed_b.as_slice());
 
@@ -1747,7 +1751,7 @@ mod table_test {
         let m = r0.get_map(31).unwrap();
         assert!(m.value_array().get_boolean(0).unwrap());
         assert!(!m.value_array().get_boolean(1).unwrap());
-        let m = r0.get_map(32).unwrap();
+        let m = r0.get_map(32).unwrap().expect_binary();
         assert_eq!(m.value_array().get_binary(0).unwrap(), fixed_a.as_slice());
         let m = r0.get_map(33).unwrap();
         assert_eq!(m.size(), 2);
@@ -1756,7 +1760,7 @@ mod table_test {
 
         // === Convenience API: entries / get / key_type / value_type ===
         // (exercised on row 0's map_string_int at index 8)
-        let m = r0.get_map(8).unwrap();
+        let m = r0.get_map(8).unwrap().expect_binary();
         assert_eq!(m.key_type(), &DataTypes::string().as_non_nullable());
         assert_eq!(m.value_type(), &DataTypes::int());
         let mut got: HashMap<String, Option<i32>> = HashMap::with_capacity(m.size());

--- a/crates/fluss/tests/integration/table_remote_scan.rs
+++ b/crates/fluss/tests/integration/table_remote_scan.rs
@@ -20,7 +20,7 @@
 mod table_remote_scan_test {
     use crate::integration::utils::{create_table, get_shared_cluster};
     use fluss::metadata::{DataTypes, Schema, TableDescriptor, TablePath};
-    use fluss::row::{GenericRow, InternalRow};
+    use fluss::row::{DataGetters, GenericRow};
     use std::time::Duration;
 
     #[tokio::test]

--- a/website/docs/user-guide/rust/api-reference.md
+++ b/website/docs/user-guide/rust/api-reference.md
@@ -484,12 +484,39 @@ Implements the `InternalRow` trait (see below).
 | `fn get_bytes(&self, idx: usize) -> Result<&[u8]>`                                     | Get bytes value                         |
 | `fn get_binary(&self, idx: usize, length: usize) -> Result<&[u8]>`                     | Get fixed-length binary value           |
 | `fn get_char(&self, idx: usize, length: usize) -> Result<&str>`                        | Get fixed-length char value             |
-| `fn get_array(&self, idx: usize) -> Result<FlussArray>`                                | Get array value                         |
-| `fn get_map(&self, idx: usize) -> Result<FlussMap>`                                    | Get map value                           |
+| `fn get_array(&self, idx: usize) -> Result<ArrayView<'_>>`                             | Get array value (zero-copy view)        |
+| `fn get_map(&self, idx: usize) -> Result<MapView<'_>>`                                 | Get map value (zero-copy view)          |
+| `fn get_row(&self, idx: usize) -> Result<RowView<'_>>`                                 | Get nested row value (zero-copy view)   |
+
+The nested getters return borrowed views — `ArrayView`, `MapView`, `RowView`. Read elements directly through the `DataGetters` accessors, or call `try_into_binary()` (`try_into_generic()` for rows) for the owned binary form.
+
+## `ArrayView<'a>`
+
+Returned by `get_array()`. Implements `InternalArray` + `DataGetters`, so elements are read in place via the typed getters (`get_int()`, `get_string()`, nested `get_array()` / `get_map()`, …).
+
+| Method | Description |
+|--------|-------------|
+| `fn try_into_binary(self) -> Result<FlussArray>` | Materialize the owned binary `FlussArray`, re-encoding a columnar slice if needed |
+
+## `MapView<'a>`
+
+Returned by `get_map()`. Implements `InternalMap`.
+
+| Method | Description |
+|--------|-------------|
+| `fn try_into_binary(self) -> Result<FlussMap>` | Materialize the owned binary `FlussMap`, re-encoding a columnar slice if needed |
+
+## `RowView<'a>`
+
+Returned by `get_row()`. Implements `InternalRow`, so nested fields are read in place via the typed getters.
+
+| Method | Description |
+|--------|-------------|
+| `fn try_into_generic(self, row_type: &RowType) -> Result<GenericRow<'static>>` | Materialize the owned `GenericRow`, walking a columnar cursor field-by-field if needed |
 
 ## `FlussArray`
 
-`FlussArray` is the Rust row representation for `ARRAY` values. You usually obtain it from `InternalRow::get_array()`.
+`FlussArray` is the owned binary row representation for `ARRAY` values. You obtain it from `ArrayView::try_into_binary()`.
 
 | Method | Description |
 |--------|-------------|
@@ -501,7 +528,7 @@ Element getters mirror `InternalRow` typed getters and return `Result<T>`. For e
 
 ## `FlussMap`
 
-`FlussMap` is the Rust row representation for `MAP` values. You usually obtain it from `InternalRow::get_map()`.
+`FlussMap` is the owned binary row representation for `MAP` values. You obtain it from `MapView::try_into_binary()`.
 
 | Method | Description |
 |--------|-------------|


### PR DESCRIPTION
### Summary

closes https://github.com/apache/fluss-rust/issues/543

ColumnarRow now holds typed Arrow column vectors built once per batch instead of downcasting on every read. Nested ARRAY/MAP/ROW return lazy slice views - no copy unless the caller asks for a binary form via try_into_binary(). 

Mirrors Java's VectorizedColumnBatch.