### PR TITLE
[elixir] Optimize CI/CD with proper actions, reusing compiled deps

### DIFF
--- a/.github/workflows/build_and_test_elixir.yml
+++ b/.github/workflows/build_and_test_elixir.yml
@@ -51,13 +51,16 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up BEAM
+        id: beam
         uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/bindings/elixir/lib/fluss/native.ex
+++ b/bindings/elixir/lib/fluss/native.ex
@@ -17,7 +17,11 @@
 
 defmodule Fluss.Native do
   @moduledoc false
-  use Rustler, otp_app: :fluss, crate: "fluss_nif"
+  # Release only when packaging for prod; debug keeps dev/test compiles fast.
+  use Rustler,
+    otp_app: :fluss,
+    crate: "fluss_nif",
+    mode: if(Mix.env() == :prod, do: :release, else: :debug)
 
   # Connection
   def connection_new(_config), do: :erlang.nif_error(:nif_not_loaded)


### PR DESCRIPTION
## Summary
closes https://github.com/apache/fluss-rust/issues/599

Elixir CI built the NIF in release mode (rustler's default), recompiling the whole fluss graph every run (4m). 
Switched it to debug for dev/test so it reuses already-built deps. 
Also fixed protoc to use the setup-protoc action and corrected the PLT cache key.