### PR TITLE
[elixir] ci: bump OTP to 28.5.0.2

### DIFF
--- a/.github/workflows/build_and_test_elixir.yml
+++ b/.github/workflows/build_and_test_elixir.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
-      OTP_VERSION: "28.0.2"
+      OTP_VERSION: "28.5.0.2"
       ELIXIR_VERSION: "1.19.5"
       FLUSS_TEST_CLUSTER_BIN: ${{ github.workspace }}/target/debug/fluss-test-cluster
       MIX_ENV: test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss-rust/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

This PR fixes the CI for Elixir bindings.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

The CI fails with:

```
Could not start Hex. Try fetching a new version with "mix local.hex" or uninstalling it with "mix archive.uninstall hex.ez"
** (MatchError) no match of right hand side value
{:failed_to_start_child, Hex.State,
         {:undef,
          [
            {:re, :import,
             [
               {:re_exported_pattern,
               ...
```

The problem here is essentially a toolchain version mismatch: the latest version of `hex` - 2.5.0 (picked by the CI action) had added a new feature that uses a regex for a duration parser, but compiled under Elixir 1.19 on OTP 28, that regex is serialized in OTP 28's new `export` form and reconstructed at load time via `re:import/1`. However, this function only since OTP 28.1 (hence the `undef`). 

So bumping the OTP version (latest 28.x) should fix this issue.